### PR TITLE
feat(dwm): apply pertag patch and overhaul visual config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,65 @@
+---
+Language: C
+BasedOnStyle: LLVM
+
+# --- indentation ---
+IndentWidth: 2
+TabWidth: 2
+UseTab: Never
+ContinuationIndentWidth: 4
+
+# --- line length ---
+ColumnLimit: 80
+
+# --- braces (K&R: opening brace on same line) ---
+BreakBeforeBraces: Attach
+
+# --- short constructs ---
+AllowShortBlocksOnASingleLine: Never
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+
+# --- spacing ---
+SpaceAfterCStyleCast: false
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesInAngles: Never
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+
+# --- pointer alignment ---
+PointerAlignment: Right
+
+# --- alignment ---
+# Align trailing /* comments */ within the same block (good for palette)
+AlignTrailingComments: true
+# No forced column padding for declarations or assignments
+AlignConsecutiveDeclarations: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveMacros: false
+# Array-of-structs: no column padding
+AlignArrayOfStructures: None
+
+# --- binary operators ---
+BreakBeforeBinaryOperators: None
+
+# --- includes ---
+# Do NOT reorder #include lines (dwm header order matters)
+SortIncludes: Never
+IncludeBlocks: Preserve
+
+# --- comments ---
+# Keep hand-formatted block comments intact
+ReflowComments: false
+
+# --- empty lines ---
+MaxEmptyLinesToKeep: 1
+KeepEmptyLinesAtTheStartOfBlocks: false
+
+# --- macros ---
+# Treat TAGKEYS and SHCMD as statement-level macros so clang-format
+# does not try to reformat their internal structure.
+StatementMacros:
+  - TAGKEYS
+  - SHCMD

--- a/config.def.h
+++ b/config.def.h
@@ -1,7 +1,9 @@
 /* See LICENSE file for copyright and license details. */
+#include <X11/XF86keysym.h>
 
 /* appearance */
 static const unsigned int borderpx = 2; /* border pixel of windows */
+static const unsigned int gappx = 8;    /* gaps between windows */
 static const unsigned int snap = 32;    /* snap pixel */
 static const unsigned int systraypinning =
     0; /* 0: sloppy systray follows selected monitor, >0: pin systray to monitor
@@ -13,27 +15,50 @@ static const int systraypinningfailfirst =
 static const int showsystray = 1; /* 0 means no systray */
 static const int showbar = 1;     /* 0 means no bar */
 static const int topbar = 1;      /* 0 means bottom bar */
-static const char *fonts[] = {"monospace:size=12"};
-static const char dmenufont[] = "monospace:size=12";
+static const char *fonts[] = {"monospace:size=11"};
+static const char dmenufont[] = "JetBrainsMono Nerd Font Mono:size=11";
 
-static const char col_gray1[] = "#282a36";
-static const char col_gray2[] = "#282a36"; /* border color unfocused windows */
-static const char col_gray3[] = "#96b5b4";
-static const char col_gray4[] = "#d7d7d7";
-static const char col_cyan[] =
-    "#924441"; /* border color focused windows and tags */
-static const char col_green[] = "#1aff1a";
-static const char col_light_blue[] = "#c335b8";
+/* --- color palette --- */
+static const char col_1[] = "#282a36"; /* dark background (Dracula) */
+static const char col_2[] = "#96b5b4"; /* muted teal */
+static const char col_3[] = "#d7d7d7"; /* light gray */
+static const char col_4[] = "#924441"; /* muted red */
+static const char col_5[] = "#1aff1a"; /* bright green */
+static const char col_6[] = "#df9443"; /* orange */
+static const char col_7[] = "#ffffff"; /* white */
+
+/* --- semantic color roles --- */
+/* bar */
+#define bar_bg col_1 /* bar background */
+#define bar_fg col_2 /* bar foreground (normal text) */
+/* selected tag / focused element */
+#define sel_bg col_7 /* selected tag background */
+#define sel_fg col_1 /* selected tag foreground */
+/* window borders */
+#define border_normal col_1  /* unfocused window border */
+#define border_focused col_7 /* focused window border */
+/* dmenu */
+#define dmenu_nb col_1 /* dmenu normal background */
+#define dmenu_nf col_2 /* dmenu normal foreground */
+#define dmenu_sb col_6 /* dmenu selected background */
+#define dmenu_sf col_3 /* dmenu selected foreground */
+
+static const char terminal_multiplexer[] = {"tmux"};
 
 static const char *colors[][3] = {
-    /*               fg         bg         border   */
-    [SchemeNorm] = {col_gray3, col_gray1, col_gray2},
-    [SchemeSel] = {col_gray1, col_green, col_green},
+    /*               fg       bg       border         */
+    [SchemeNorm] = {bar_fg, bar_bg, border_normal},
+    [SchemeSel] = {sel_fg, sel_bg, border_focused},
 };
 
 /* tagging */
-static const char *tags[] = {"", "", "", "", "",
-                             "", "", "", ""};
+static const char *tags[] = {"1", "2", "3", "4", "5", "6", "7", "8", "9"};
+// static const char *tags[] = { "ⅼ","Ⅱ","Ⅲ","Ⅳ","Ⅴ","Ⅵ","Ⅶ","Ⅷ","Ⅸ" };
+//  static const char *tags[] = { "♠", "♡", "♢", "♣", "♤", "♥", "♦", "♧", "✦"};
+// static const char *tags[] = { "", "", "", "", "", "",
+// "", "", "" }; static const char *tags[] = {
+// "☽","☾","🌑","🌒","🌓","🌔","🌕","🌖","🌘" }; static const char *tags[] = {
+// "𖤍","𓅂","࿐","ௐ","ஒ","៚","༆","Ӂ","༫" };
 
 static const Rule rules[] = {
     /* xprop(1):
@@ -41,9 +66,10 @@ static const Rule rules[] = {
      *	WM_NAME(STRING) = title
      */
     /* class      instance    title       tags mask     isfloating   monitor */
-    {"Gimp", NULL, NULL, 0, 1, -1},
-    {"Firefox", NULL, NULL, 1 << 8, 0, -1},
-};
+    {"gimp", NULL, NULL, 0, 1, -1},
+    {"firefox", NULL, NULL, 1 << 4, 0, -1},
+    {"Telegram", NULL, NULL, 1 << 7, 0, -1},
+    {"discord", NULL, NULL, 1 << 8, 0, 1}};
 
 /* layout(s) */
 static const float mfact = 0.55; /* factor of master area size [0.05..0.95] */
@@ -53,9 +79,9 @@ static const int resizehints =
 
 static const Layout layouts[] = {
     /* symbol     arrange function */
-    {"[]=", tile}, /* first entry is default */
-    {"><>", NULL}, /* no layout function means floating behavior */
-    {"[M]", monocle},
+    {"[𝕋]", tile}, /* first entry is default */
+    {"[𝔽]", NULL}, /* no layout function means floating behavior */
+    {"[𝕄]", monocle},
 };
 
 /* key definitions */
@@ -67,20 +93,29 @@ static const Layout layouts[] = {
       {MODKEY | ControlMask | ShiftMask, KEY, toggletag, {.ui = 1 << TAG}},
 
 /* helper for spawning shell commands in the pre dwm-5.0 fashion */
+// clang-format off
 #define SHCMD(cmd)                                                             \
   {                                                                            \
     .v = (const char *[]) { "/bin/sh", "-c", cmd, NULL }                       \
   }
+// clang-format on
 
 /* commands */
 static char dmenumon[2] =
     "0"; /* component of dmenucmd, manipulated in spawn() */
 static const char *dmenucmd[] = {
-    "dmenu_run", "-m",      dmenumon, "-fn",    dmenufont, "-nb",     col_gray1,
-    "-nf",       col_gray3, "-sb",    col_cyan, "-sf",     col_gray4, NULL};
-static const char *termcmd[] = {"st", NULL};
+    "dmenu_run", "-m",     dmenumon, "-fn",    dmenufont, "-nb",    dmenu_nb,
+    "-nf",       dmenu_nf, "-sb",    dmenu_sb, "-sf",     dmenu_sf, NULL};
+static const char *termcmd[] = {"kitty", "-e", terminal_multiplexer};
+/* volume */
+static const char *upvol[] = {"/usr/bin/pamixer", "-i", "5", NULL, NULL};
+static const char *downvol[] = {"/usr/bin/pamixer", "-d", "5", NULL, NULL};
+static const char *mutevol[] = {"/usr/bin/pamixer", "-t", NULL, NULL, NULL};
 
 static Key keys[] = {
+    {0, XF86XK_AudioLowerVolume, spawn, {.v = downvol}},
+    {0, XF86XK_AudioMute, spawn, {.v = mutevol}},
+    {0, XF86XK_AudioRaiseVolume, spawn, {.v = upvol}},
     /* modifier                     key        function        argument */
     {MODKEY, XK_p, spawn, {.v = dmenucmd}},
     {MODKEY | ShiftMask, XK_Return, spawn, {.v = termcmd}},

--- a/config.h
+++ b/config.h
@@ -16,30 +16,47 @@ static const int showsystray = 1; /* 0 means no systray */
 static const int showbar = 1;     /* 0 means no bar */
 static const int topbar = 1;      /* 0 means bottom bar */
 static const char *fonts[] = {"monospace:size=11"};
-static const char dmenufont[] = "monospace:size=11";
+static const char dmenufont[] = "JetBrainsMono Nerd Font Mono:size=11";
 
-static const char col_gray1[] = "#282a36";
-static const char col_gray2[] = "#282a36"; /* border color unfocused windows */
-static const char col_gray3[] = "#96b5b4";
-static const char col_gray4[] = "#d7d7d7";
-static const char col_cyan[] =
-    "#924441"; /* border color focused windows and tags */
-static const char col_green[] = "#1aff1a";
-static const char col_orange[] = "#df9443";
-static const char col_light_blue[] = "#ffffff";
+/* --- color palette --- */
+static const char col_1[] = "#282a36"; /* dark background (Dracula) */
+static const char col_2[] = "#96b5b4"; /* muted teal */
+static const char col_3[] = "#d7d7d7"; /* light gray */
+static const char col_4[] = "#924441"; /* muted red */
+static const char col_5[] = "#1aff1a"; /* bright green */
+static const char col_6[] = "#df9443"; /* orange */
+static const char col_7[] = "#ffffff"; /* white */
+
+/* --- semantic color roles --- */
+/* bar */
+#define bar_bg col_1 /* bar background */
+#define bar_fg col_2 /* bar foreground (normal text) */
+/* selected tag / focused element */
+#define sel_bg col_7 /* selected tag background */
+#define sel_fg col_1 /* selected tag foreground */
+/* window borders */
+#define border_normal col_1  /* unfocused window border */
+#define border_focused col_7 /* focused window border */
+/* dmenu */
+#define dmenu_nb col_1 /* dmenu normal background */
+#define dmenu_nf col_2 /* dmenu normal foreground */
+#define dmenu_sb col_6 /* dmenu selected background */
+#define dmenu_sf col_3 /* dmenu selected foreground */
+
+static const char terminal_multiplexer[] = {"tmux"};
 
 static const char *colors[][3] = {
-    /*               fg         bg         border   */
-    [SchemeNorm] = {col_gray3, col_gray1, col_gray2},
-    [SchemeSel] = {col_gray1, col_light_blue, col_light_blue},
+    /*               fg       bg       border         */
+    [SchemeNorm] = {bar_fg, bar_bg, border_normal},
+    [SchemeSel] = {sel_fg, sel_bg, border_focused},
 };
 
 /* tagging */
 static const char *tags[] = {"1", "2", "3", "4", "5", "6", "7", "8", "9"};
 // static const char *tags[] = { "ⅼ","Ⅱ","Ⅲ","Ⅳ","Ⅴ","Ⅵ","Ⅶ","Ⅷ","Ⅸ" };
 //  static const char *tags[] = { "♠", "♡", "♢", "♣", "♤", "♥", "♦", "♧", "✦"};
-// static const char *tags[] = { "", "", "", "", "", "",
-// "", "", "" }; static const char *tags[] = {
+// static const char *tags[] = { "", "", "", "", "", "",
+// "", "", "" }; static const char *tags[] = {
 // "☽","☾","🌑","🌒","🌓","🌔","🌕","🌖","🌘" }; static const char *tags[] = {
 // "𖤍","𓅂","࿐","ௐ","ஒ","៚","༆","Ӂ","༫" };
 
@@ -52,7 +69,7 @@ static const Rule rules[] = {
     {"gimp", NULL, NULL, 0, 1, -1},
     {"firefox", NULL, NULL, 1 << 4, 0, -1},
     {"Telegram", NULL, NULL, 1 << 7, 0, -1},
-    {"discord", NULL, NULL, 1 << 9, 0, 1}};
+    {"discord", NULL, NULL, 1 << 8, 0, 1}};
 
 /* layout(s) */
 static const float mfact = 0.55; /* factor of master area size [0.05..0.95] */
@@ -76,19 +93,21 @@ static const Layout layouts[] = {
       {MODKEY | ControlMask | ShiftMask, KEY, toggletag, {.ui = 1 << TAG}},
 
 /* helper for spawning shell commands in the pre dwm-5.0 fashion */
+// clang-format off
 #define SHCMD(cmd)                                                             \
   {                                                                            \
     .v = (const char *[]) { "/bin/sh", "-c", cmd, NULL }                       \
   }
+// clang-format on
 
 /* commands */
 static char dmenumon[2] =
     "0"; /* component of dmenucmd, manipulated in spawn() */
 static const char *dmenucmd[] = {
-    "dmenu_run", "-m",  dmenumon,   "-fn", dmenufont, "-nb", col_gray1, "-nf",
-    col_gray3,   "-sb", col_orange, "-sf", col_gray4, NULL};
-static const char *termcmd[] = {"kitty", "-e", "tmux"};
-// Volume
+    "dmenu_run", "-m",     dmenumon, "-fn",    dmenufont, "-nb",    dmenu_nb,
+    "-nf",       dmenu_nf, "-sb",    dmenu_sb, "-sf",     dmenu_sf, NULL};
+static const char *termcmd[] = {"kitty", "-e", terminal_multiplexer};
+/* volume */
 static const char *upvol[] = {"/usr/bin/pamixer", "-i", "5", NULL, NULL};
 static const char *downvol[] = {"/usr/bin/pamixer", "-d", "5", NULL, NULL};
 static const char *mutevol[] = {"/usr/bin/pamixer", "-t", NULL, NULL, NULL};
@@ -130,8 +149,7 @@ static Key keys[] = {
 /* click can be ClkTagBar, ClkLtSymbol, ClkStatusText, ClkWinTitle,
  * ClkClientWin, or ClkRootWin */
 static Button buttons[] = {
-    /* click                event mask      button          function
-       argument */
+    /* click                event mask      button          function argument */
     {ClkLtSymbol, 0, Button1, setlayout, {0}},
     {ClkLtSymbol, 0, Button3, setlayout, {.v = &layouts[2]}},
     {ClkWinTitle, 0, Button2, zoom, {0}},

--- a/dwm.c
+++ b/dwm.c
@@ -45,132 +45,163 @@
 #include "util.h"
 
 /* macros */
-#define BUTTONMASK              (ButtonPressMask|ButtonReleaseMask)
-#define CLEANMASK(mask)         (mask & ~(numlockmask|LockMask) & (ShiftMask|ControlMask|Mod1Mask|Mod2Mask|Mod3Mask|Mod4Mask|Mod5Mask))
-#define INTERSECT(x,y,w,h,m)    (MAX(0, MIN((x)+(w),(m)->wx+(m)->ww) - MAX((x),(m)->wx)) \
-                               * MAX(0, MIN((y)+(h),(m)->wy+(m)->wh) - MAX((y),(m)->wy)))
-#define ISVISIBLE(C)            ((C->tags & C->mon->tagset[C->mon->seltags]))
+#define BUTTONMASK (ButtonPressMask | ButtonReleaseMask)
+#define CLEANMASK(mask)                                                        \
+  (mask & ~(numlockmask | LockMask) &                                          \
+   (ShiftMask | ControlMask | Mod1Mask | Mod2Mask | Mod3Mask | Mod4Mask |      \
+    Mod5Mask))
+#define INTERSECT(x, y, w, h, m)                                               \
+  (MAX(0, MIN((x) + (w), (m)->wx + (m)->ww) - MAX((x), (m)->wx)) *             \
+   MAX(0, MIN((y) + (h), (m)->wy + (m)->wh) - MAX((y), (m)->wy)))
+#define ISVISIBLE(C) ((C->tags & C->mon->tagset[C->mon->seltags]))
 
-#define LENGTH(X)               ((sizeof(X)) / (sizeof X[0]))
+#define LENGTH(X) ((sizeof(X)) / (sizeof X[0]))
 
-#define MOUSEMASK               (BUTTONMASK|PointerMotionMask)
-#define WIDTH(X)                ((X)->w + 2 * (X)->bw)
-#define HEIGHT(X)               ((X)->h + 2 * (X)->bw)
-#define TAGMASK                 ((1 << LENGTH(tags)) - 1)
-#define TEXTW(X)                (drw_fontset_getwidth(drw, (X)) + lrpad)
+#define MOUSEMASK (BUTTONMASK | PointerMotionMask)
+#define WIDTH(X) ((X)->w + 2 * (X)->bw)
+#define HEIGHT(X) ((X)->h + 2 * (X)->bw)
+#define TAGMASK ((1 << LENGTH(tags)) - 1)
+#define TEXTW(X) (drw_fontset_getwidth(drw, (X)) + lrpad)
 
-#define SYSTEM_TRAY_REQUEST_DOCK    0
+#define SYSTEM_TRAY_REQUEST_DOCK 0
 
 /* XEMBED messages */
-#define XEMBED_EMBEDDED_NOTIFY      0
-#define XEMBED_WINDOW_ACTIVATE      1
-#define XEMBED_FOCUS_IN             4
-#define XEMBED_MODALITY_ON         10
+#define XEMBED_EMBEDDED_NOTIFY 0
+#define XEMBED_WINDOW_ACTIVATE 1
+#define XEMBED_FOCUS_IN 4
+#define XEMBED_MODALITY_ON 10
 
-#define XEMBED_MAPPED              (1 << 0)
-#define XEMBED_WINDOW_ACTIVATE      1
-#define XEMBED_WINDOW_DEACTIVATE    2
+#define XEMBED_MAPPED (1 << 0)
+#define XEMBED_WINDOW_DEACTIVATE 2
 
-#define VERSION_MAJOR               0
-#define VERSION_MINOR               0
+#define VERSION_MAJOR 0
+#define VERSION_MINOR 0
 #define XEMBED_EMBEDDED_VERSION (VERSION_MAJOR << 16) | VERSION_MINOR
 
 /* enums */
 enum { CurNormal, CurResize, CurMove, CurLast }; /* cursor */
-enum { SchemeNorm, SchemeSel }; /* color schemes */
-enum { NetSupported, NetWMName, NetWMState, NetWMCheck,
-       NetSystemTray, NetSystemTrayOP, NetSystemTrayOrientation, NetSystemTrayOrientationHorz,
-       NetWMFullscreen, NetActiveWindow, NetWMWindowType,
-       NetWMWindowTypeDialog, NetClientList, NetLast }; /* EWMH atoms */
+enum { SchemeNorm, SchemeSel };                  /* color schemes */
+enum {
+  NetSupported,
+  NetWMName,
+  NetWMState,
+  NetWMCheck,
+  NetSystemTray,
+  NetSystemTrayOP,
+  NetSystemTrayOrientation,
+  NetSystemTrayOrientationHorz,
+  NetWMFullscreen,
+  NetActiveWindow,
+  NetWMWindowType,
+  NetWMWindowTypeDialog,
+  NetClientList,
+  NetLast
+}; /* EWMH atoms */
 enum { Manager, Xembed, XembedInfo, XLast }; /* Xembed atoms */
-enum { WMProtocols, WMDelete, WMState, WMTakeFocus, WMLast }; /* default atoms */
-enum { ClkTagBar, ClkLtSymbol, ClkStatusText, ClkWinTitle,
-       ClkClientWin, ClkRootWin, ClkLast }; /* clicks */
+enum {
+  WMProtocols,
+  WMDelete,
+  WMState,
+  WMTakeFocus,
+  WMLast
+}; /* default atoms */
+enum {
+  ClkTagBar,
+  ClkLtSymbol,
+  ClkStatusText,
+  ClkWinTitle,
+  ClkClientWin,
+  ClkRootWin,
+  ClkLast
+}; /* clicks */
 
 typedef union {
-	int i;
-	unsigned int ui;
-	float f;
-	const void *v;
+  int i;
+  unsigned int ui;
+  float f;
+  const void *v;
 } Arg;
 
 typedef struct {
-	unsigned int click;
-	unsigned int mask;
-	unsigned int button;
-	void (*func)(const Arg *arg);
-	const Arg arg;
+  unsigned int click;
+  unsigned int mask;
+  unsigned int button;
+  void (*func)(const Arg *arg);
+  const Arg arg;
 } Button;
 
 typedef struct Monitor Monitor;
 typedef struct Client Client;
 struct Client {
-	char name[256];
-	float mina, maxa;
-	int x, y, w, h;
-	int oldx, oldy, oldw, oldh;
-	int basew, baseh, incw, inch, maxw, maxh, minw, minh;
-	int bw, oldbw;
-	unsigned int tags;
-	int isfixed, isfloating, isurgent, neverfocus, oldstate, isfullscreen;
-	Client *next;
-	Client *snext;
-	Monitor *mon;
-	Window win;
+  char name[256];
+  float mina, maxa;
+  int x, y, w, h;
+  int oldx, oldy, oldw, oldh;
+  int basew, baseh, incw, inch, maxw, maxh, minw, minh;
+  int bw, oldbw;
+  unsigned int tags;
+  int isfixed, isfloating, isurgent, neverfocus, oldstate, isfullscreen;
+  Client *next;
+  Client *snext;
+  Monitor *mon;
+  Window win;
 };
 
 typedef struct {
-	unsigned int mod;
-	KeySym keysym;
-	void (*func)(const Arg *);
-	const Arg arg;
+  unsigned int mod;
+  KeySym keysym;
+  void (*func)(const Arg *);
+  const Arg arg;
 } Key;
 
 typedef struct {
-	const char *symbol;
-	void (*arrange)(Monitor *);
+  const char *symbol;
+  void (*arrange)(Monitor *);
 } Layout;
 
+typedef struct Pertag Pertag;
 struct Monitor {
-	char ltsymbol[16];
-	float mfact;
-	int nmaster;
-	int num;
-	int by;               /* bar geometry */
-	int mx, my, mw, mh;   /* screen size */
-	int wx, wy, ww, wh;   /* window area  */
-	int gappx;            /* gaps between windows */
-	unsigned int seltags;
-	unsigned int sellt;
-	unsigned int tagset[2];
-	int showbar;
-	int topbar;
-	Client *clients;
-	Client *sel;
-	Client *stack;
-	Monitor *next;
-	Window barwin;
-	const Layout *lt[2];
+  char ltsymbol[16];
+  float mfact;
+  int nmaster;
+  int num;
+  int by;             /* bar geometry */
+  int mx, my, mw, mh; /* screen size */
+  int wx, wy, ww, wh; /* window area  */
+  int gappx;          /* gaps between windows */
+  unsigned int seltags;
+  unsigned int sellt;
+  unsigned int tagset[2];
+  int showbar;
+  int topbar;
+  Client *clients;
+  Client *sel;
+  Client *stack;
+  Monitor *next;
+  Window barwin;
+  const Layout *lt[2];
+  Pertag *pertag;
 };
 
 typedef struct {
-	const char *class;
-	const char *instance;
-	const char *title;
-	unsigned int tags;
-	int isfloating;
-	int monitor;
+  const char *class;
+  const char *instance;
+  const char *title;
+  unsigned int tags;
+  int isfloating;
+  int monitor;
 } Rule;
 
-typedef struct Systray   Systray;
+typedef struct Systray Systray;
 struct Systray {
-	Window win;
-	Client *icons;
+  Window win;
+  Client *icons;
 };
 
 /* function declarations */
 static void applyrules(Client *c);
-static int applysizehints(Client *c, int *x, int *y, int *w, int *h, int interact);
+static int applysizehints(Client *c, int *x, int *y, int *w, int *h,
+                          int interact);
 static void arrange(Monitor *m);
 static void arrangemon(Monitor *m);
 static void attach(Client *c);
@@ -226,7 +257,8 @@ static void resizerequest(XEvent *e);
 static void restack(Monitor *m);
 static void run(void);
 static void scan(void);
-static int sendevent(Window w, Atom proto, int m, long d0, long d1, long d2, long d3, long d4);
+static int sendevent(Window w, Atom proto, int m, long d0, long d1, long d2,
+                     long d3, long d4);
 static void sendmon(Client *c, Monitor *m);
 static void setclientstate(Client *c, long state);
 static void setfocus(Client *c);
@@ -273,32 +305,31 @@ static int xerrorstart(Display *dpy, XErrorEvent *ee);
 static void zoom(const Arg *arg);
 
 /* variables */
-static Systray *systray =  NULL;
+static Systray *systray = NULL;
 static const char broken[] = "broken";
 static char stext[256];
 static int screen;
-static int sw, sh;           /* X display screen geometry width, height */
-static int bh, blw = 0;      /* bar geometry */
-static int lrpad;            /* sum of left and right padding for text */
+static int sw, sh;      /* X display screen geometry width, height */
+static int bh, blw = 0; /* bar geometry */
+static int lrpad;       /* sum of left and right padding for text */
 static int (*xerrorxlib)(Display *, XErrorEvent *);
 static unsigned int numlockmask = 0;
-static void (*handler[LASTEvent]) (XEvent *) = {
-	[ButtonPress] = buttonpress,
-	[ClientMessage] = clientmessage,
-	[ConfigureRequest] = configurerequest,
-	[ConfigureNotify] = configurenotify,
-	[DestroyNotify] = destroynotify,
-	[EnterNotify] = enternotify,
-	[Expose] = expose,
-	[FocusIn] = focusin,
-	[KeyPress] = keypress,
-	[MappingNotify] = mappingnotify,
-	[MapRequest] = maprequest,
-	[MotionNotify] = motionnotify,
-	[PropertyNotify] = propertynotify,
-	[ResizeRequest] = resizerequest,
-	[UnmapNotify] = unmapnotify
-};
+static void (*handler[LASTEvent])(XEvent *) = {
+    [ButtonPress] = buttonpress,
+    [ClientMessage] = clientmessage,
+    [ConfigureRequest] = configurerequest,
+    [ConfigureNotify] = configurenotify,
+    [DestroyNotify] = destroynotify,
+    [EnterNotify] = enternotify,
+    [Expose] = expose,
+    [FocusIn] = focusin,
+    [KeyPress] = keypress,
+    [MappingNotify] = mappingnotify,
+    [MapRequest] = maprequest,
+    [MotionNotify] = motionnotify,
+    [PropertyNotify] = propertynotify,
+    [ResizeRequest] = resizerequest,
+    [UnmapNotify] = unmapnotify};
 static Atom wmatom[WMLast], netatom[NetLast], xatom[XLast];
 static int running = 1;
 static Cur *cursor[CurLast];
@@ -311,2214 +342,2170 @@ static Window root, wmcheckwin;
 /* configuration, allows nested code to access above variables */
 #include "config.h"
 
+struct Pertag {
+  unsigned int curtag, prevtag;          /* current and previous tag */
+  int nmasters[LENGTH(tags) + 1];        /* number of windows in master area */
+  float mfacts[LENGTH(tags) + 1];        /* mfacts per tag */
+  unsigned int sellts[LENGTH(tags) + 1]; /* selected layouts */
+  const Layout
+      *ltidxs[LENGTH(tags) + 1][2]; /* matrix of tags and layouts indexes */
+  int showbars[LENGTH(tags) + 1];   /* display bar for the current tag */
+};
+
 /* compile-time check if all tags fit into an unsigned int bit array. */
-struct NumTags { char limitexceeded[LENGTH(tags) > 31 ? -1 : 1]; };
+struct NumTags {
+  char limitexceeded[LENGTH(tags) > 31 ? -1 : 1];
+};
 
 /* function implementations */
-void
-applyrules(Client *c)
-{
-	const char *class, *instance;
-	unsigned int i;
-	const Rule *r;
-	Monitor *m;
-	XClassHint ch = { NULL, NULL };
+void applyrules(Client *c) {
+  const char *class, *instance;
+  unsigned int i;
+  const Rule *r;
+  Monitor *m;
+  XClassHint ch = {NULL, NULL};
 
-	/* rule matching */
-	c->isfloating = 0;
-	c->tags = 0;
-	XGetClassHint(dpy, c->win, &ch);
-	class    = ch.res_class ? ch.res_class : broken;
-	instance = ch.res_name  ? ch.res_name  : broken;
+  /* rule matching */
+  c->isfloating = 0;
+  c->tags = 0;
+  XGetClassHint(dpy, c->win, &ch);
+  class = ch.res_class ? ch.res_class : broken;
+  instance = ch.res_name ? ch.res_name : broken;
 
-	for (i = 0; i < LENGTH(rules); i++) {
-		r = &rules[i];
-		if ((!r->title || strstr(c->name, r->title))
-		&& (!r->class || strstr(class, r->class))
-		&& (!r->instance || strstr(instance, r->instance)))
-		{
-			c->isfloating = r->isfloating;
-			c->tags |= r->tags;
-			for (m = mons; m && m->num != r->monitor; m = m->next);
-			if (m)
-				c->mon = m;
-		}
-	}
-	if (ch.res_class)
-		XFree(ch.res_class);
-	if (ch.res_name)
-		XFree(ch.res_name);
-	c->tags = c->tags & TAGMASK ? c->tags & TAGMASK : c->mon->tagset[c->mon->seltags];
+  for (i = 0; i < LENGTH(rules); i++) {
+    r = &rules[i];
+    if ((!r->title || strstr(c->name, r->title)) &&
+        (!r->class || strstr(class, r->class)) &&
+        (!r->instance || strstr(instance, r->instance))) {
+      c->isfloating = r->isfloating;
+      c->tags |= r->tags;
+      for (m = mons; m && m->num != r->monitor; m = m->next)
+        ;
+      if (m)
+        c->mon = m;
+    }
+  }
+  if (ch.res_class)
+    XFree(ch.res_class);
+  if (ch.res_name)
+    XFree(ch.res_name);
+  c->tags =
+      c->tags & TAGMASK ? c->tags & TAGMASK : c->mon->tagset[c->mon->seltags];
 }
 
-int
-applysizehints(Client *c, int *x, int *y, int *w, int *h, int interact)
-{
-	int baseismin;
-	Monitor *m = c->mon;
+int applysizehints(Client *c, int *x, int *y, int *w, int *h, int interact) {
+  int baseismin;
+  Monitor *m = c->mon;
 
-	/* set minimum possible */
-	*w = MAX(1, *w);
-	*h = MAX(1, *h);
-	if (interact) {
-		if (*x > sw)
-			*x = sw - WIDTH(c);
-		if (*y > sh)
-			*y = sh - HEIGHT(c);
-		if (*x + *w + 2 * c->bw < 0)
-			*x = 0;
-		if (*y + *h + 2 * c->bw < 0)
-			*y = 0;
-	} else {
-		if (*x >= m->wx + m->ww)
-			*x = m->wx + m->ww - WIDTH(c);
-		if (*y >= m->wy + m->wh)
-			*y = m->wy + m->wh - HEIGHT(c);
-		if (*x + *w + 2 * c->bw <= m->wx)
-			*x = m->wx;
-		if (*y + *h + 2 * c->bw <= m->wy)
-			*y = m->wy;
-	}
-	if (*h < bh)
-		*h = bh;
-	if (*w < bh)
-		*w = bh;
-	if (resizehints || c->isfloating || !c->mon->lt[c->mon->sellt]->arrange) {
-		/* see last two sentences in ICCCM 4.1.2.3 */
-		baseismin = c->basew == c->minw && c->baseh == c->minh;
-		if (!baseismin) { /* temporarily remove base dimensions */
-			*w -= c->basew;
-			*h -= c->baseh;
-		}
-		/* adjust for aspect limits */
-		if (c->mina > 0 && c->maxa > 0) {
-			if (c->maxa < (float)*w / *h)
-				*w = *h * c->maxa + 0.5;
-			else if (c->mina < (float)*h / *w)
-				*h = *w * c->mina + 0.5;
-		}
-		if (baseismin) { /* increment calculation requires this */
-			*w -= c->basew;
-			*h -= c->baseh;
-		}
-		/* adjust for increment value */
-		if (c->incw)
-			*w -= *w % c->incw;
-		if (c->inch)
-			*h -= *h % c->inch;
-		/* restore base dimensions */
-		*w = MAX(*w + c->basew, c->minw);
-		*h = MAX(*h + c->baseh, c->minh);
-		if (c->maxw)
-			*w = MIN(*w, c->maxw);
-		if (c->maxh)
-			*h = MIN(*h, c->maxh);
-	}
-	return *x != c->x || *y != c->y || *w != c->w || *h != c->h;
+  /* set minimum possible */
+  *w = MAX(1, *w);
+  *h = MAX(1, *h);
+  if (interact) {
+    if (*x > sw)
+      *x = sw - WIDTH(c);
+    if (*y > sh)
+      *y = sh - HEIGHT(c);
+    if (*x + *w + 2 * c->bw < 0)
+      *x = 0;
+    if (*y + *h + 2 * c->bw < 0)
+      *y = 0;
+  } else {
+    if (*x >= m->wx + m->ww)
+      *x = m->wx + m->ww - WIDTH(c);
+    if (*y >= m->wy + m->wh)
+      *y = m->wy + m->wh - HEIGHT(c);
+    if (*x + *w + 2 * c->bw <= m->wx)
+      *x = m->wx;
+    if (*y + *h + 2 * c->bw <= m->wy)
+      *y = m->wy;
+  }
+  if (*h < bh)
+    *h = bh;
+  if (*w < bh)
+    *w = bh;
+  if (resizehints || c->isfloating || !c->mon->lt[c->mon->sellt]->arrange) {
+    /* see last two sentences in ICCCM 4.1.2.3 */
+    baseismin = c->basew == c->minw && c->baseh == c->minh;
+    if (!baseismin) { /* temporarily remove base dimensions */
+      *w -= c->basew;
+      *h -= c->baseh;
+    }
+    /* adjust for aspect limits */
+    if (c->mina > 0 && c->maxa > 0) {
+      if (c->maxa < (float)*w / *h)
+        *w = *h * c->maxa + 0.5;
+      else if (c->mina < (float)*h / *w)
+        *h = *w * c->mina + 0.5;
+    }
+    if (baseismin) { /* increment calculation requires this */
+      *w -= c->basew;
+      *h -= c->baseh;
+    }
+    /* adjust for increment value */
+    if (c->incw)
+      *w -= *w % c->incw;
+    if (c->inch)
+      *h -= *h % c->inch;
+    /* restore base dimensions */
+    *w = MAX(*w + c->basew, c->minw);
+    *h = MAX(*h + c->baseh, c->minh);
+    if (c->maxw)
+      *w = MIN(*w, c->maxw);
+    if (c->maxh)
+      *h = MIN(*h, c->maxh);
+  }
+  return *x != c->x || *y != c->y || *w != c->w || *h != c->h;
 }
 
-void
-arrange(Monitor *m)
-{
-	if (m)
-		showhide(m->stack);
-	else for (m = mons; m; m = m->next)
-		showhide(m->stack);
-	if (m) {
-		arrangemon(m);
-		restack(m);
-	} else for (m = mons; m; m = m->next)
-		arrangemon(m);
+void arrange(Monitor *m) {
+  if (m)
+    showhide(m->stack);
+  else
+    for (m = mons; m; m = m->next)
+      showhide(m->stack);
+  if (m) {
+    arrangemon(m);
+    restack(m);
+  } else
+    for (m = mons; m; m = m->next)
+      arrangemon(m);
 }
 
-void
-arrangemon(Monitor *m)
-{
-	strncpy(m->ltsymbol, m->lt[m->sellt]->symbol, sizeof m->ltsymbol);
-	if (m->lt[m->sellt]->arrange)
-		m->lt[m->sellt]->arrange(m);
+void arrangemon(Monitor *m) {
+  strncpy(m->ltsymbol, m->lt[m->sellt]->symbol, sizeof m->ltsymbol);
+  if (m->lt[m->sellt]->arrange)
+    m->lt[m->sellt]->arrange(m);
 }
 
-void
-attach(Client *c)
-{
-	c->next = c->mon->clients;
-	c->mon->clients = c;
+void attach(Client *c) {
+  c->next = c->mon->clients;
+  c->mon->clients = c;
 }
 
-void
-attachstack(Client *c)
-{
-	c->snext = c->mon->stack;
-	c->mon->stack = c;
+void attachstack(Client *c) {
+  c->snext = c->mon->stack;
+  c->mon->stack = c;
 }
 
-void
-buttonpress(XEvent *e)
-{
-	unsigned int i, x, click;
-	Arg arg = {0};
-	Client *c;
-	Monitor *m;
-	XButtonPressedEvent *ev = &e->xbutton;
+void buttonpress(XEvent *e) {
+  unsigned int i, x, click;
+  Arg arg = {0};
+  Client *c;
+  Monitor *m;
+  XButtonPressedEvent *ev = &e->xbutton;
 
-	click = ClkRootWin;
-	/* focus monitor if necessary */
-	if ((m = wintomon(ev->window)) && m != selmon) {
-		unfocus(selmon->sel, 1);
-		selmon = m;
-		focus(NULL);
-	}
-	if (ev->window == selmon->barwin) {
-		i = x = 0;
-		do
-			x += TEXTW(tags[i]);
-		while (ev->x >= x && ++i < LENGTH(tags));
-		if (i < LENGTH(tags)) {
-			click = ClkTagBar;
-			arg.ui = 1 << i;
-		} else if (ev->x < x + blw)
-			click = ClkLtSymbol;
-		else if (ev->x > selmon->ww - TEXTW(stext) - getsystraywidth())
-			click = ClkStatusText;
-		else
-			click = ClkWinTitle;
-	} else if ((c = wintoclient(ev->window))) {
-		focus(c);
-		restack(selmon);
-		XAllowEvents(dpy, ReplayPointer, CurrentTime);
-		click = ClkClientWin;
-	}
-	for (i = 0; i < LENGTH(buttons); i++)
-		if (click == buttons[i].click && buttons[i].func && buttons[i].button == ev->button
-		&& CLEANMASK(buttons[i].mask) == CLEANMASK(ev->state))
-			buttons[i].func(click == ClkTagBar && buttons[i].arg.i == 0 ? &arg : &buttons[i].arg);
+  click = ClkRootWin;
+  /* focus monitor if necessary */
+  if ((m = wintomon(ev->window)) && m != selmon) {
+    unfocus(selmon->sel, 1);
+    selmon = m;
+    focus(NULL);
+  }
+  if (ev->window == selmon->barwin) {
+    i = x = 0;
+    do
+      x += TEXTW(tags[i]);
+    while (ev->x >= x && ++i < LENGTH(tags));
+    if (i < LENGTH(tags)) {
+      click = ClkTagBar;
+      arg.ui = 1 << i;
+    } else if (ev->x < x + blw)
+      click = ClkLtSymbol;
+    else if (ev->x > selmon->ww - TEXTW(stext) - getsystraywidth())
+      click = ClkStatusText;
+    else
+      click = ClkWinTitle;
+  } else if ((c = wintoclient(ev->window))) {
+    focus(c);
+    restack(selmon);
+    XAllowEvents(dpy, ReplayPointer, CurrentTime);
+    click = ClkClientWin;
+  }
+  for (i = 0; i < LENGTH(buttons); i++)
+    if (click == buttons[i].click && buttons[i].func &&
+        buttons[i].button == ev->button &&
+        CLEANMASK(buttons[i].mask) == CLEANMASK(ev->state))
+      buttons[i].func(
+          click == ClkTagBar && buttons[i].arg.i == 0 ? &arg : &buttons[i].arg);
 }
 
-void
-checkotherwm(void)
-{
-	xerrorxlib = XSetErrorHandler(xerrorstart);
-	/* this causes an error if some other window manager is running */
-	XSelectInput(dpy, DefaultRootWindow(dpy), SubstructureRedirectMask);
-	XSync(dpy, False);
-	XSetErrorHandler(xerror);
-	XSync(dpy, False);
+void checkotherwm(void) {
+  xerrorxlib = XSetErrorHandler(xerrorstart);
+  /* this causes an error if some other window manager is running */
+  XSelectInput(dpy, DefaultRootWindow(dpy), SubstructureRedirectMask);
+  XSync(dpy, False);
+  XSetErrorHandler(xerror);
+  XSync(dpy, False);
 }
 
-void
-cleanup(void)
-{
-	Arg a = {.ui = ~0};
-	Layout foo = { "", NULL };
-	Monitor *m;
-	size_t i;
+void cleanup(void) {
+  Arg a = {.ui = ~0};
+  Layout foo = {"", NULL};
+  Monitor *m;
+  size_t i;
 
-	view(&a);
-	selmon->lt[selmon->sellt] = &foo;
-	for (m = mons; m; m = m->next)
-		while (m->stack)
-			unmanage(m->stack, 0);
-	XUngrabKey(dpy, AnyKey, AnyModifier, root);
-	while (mons)
-		cleanupmon(mons);
-	if (showsystray) {
-		XUnmapWindow(dpy, systray->win);
-		XDestroyWindow(dpy, systray->win);
-		free(systray);
-	}
-	for (i = 0; i < CurLast; i++)
-		drw_cur_free(drw, cursor[i]);
-	for (i = 0; i < LENGTH(colors); i++)
-		free(scheme[i]);
-	XDestroyWindow(dpy, wmcheckwin);
-	drw_free(drw);
-	XSync(dpy, False);
-	XSetInputFocus(dpy, PointerRoot, RevertToPointerRoot, CurrentTime);
-	XDeleteProperty(dpy, root, netatom[NetActiveWindow]);
+  view(&a);
+  selmon->lt[selmon->sellt] = &foo;
+  for (m = mons; m; m = m->next)
+    while (m->stack)
+      unmanage(m->stack, 0);
+  XUngrabKey(dpy, AnyKey, AnyModifier, root);
+  while (mons)
+    cleanupmon(mons);
+  if (showsystray) {
+    XUnmapWindow(dpy, systray->win);
+    XDestroyWindow(dpy, systray->win);
+    free(systray);
+  }
+  for (i = 0; i < CurLast; i++)
+    drw_cur_free(drw, cursor[i]);
+  for (i = 0; i < LENGTH(colors); i++)
+    free(scheme[i]);
+  XDestroyWindow(dpy, wmcheckwin);
+  drw_free(drw);
+  XSync(dpy, False);
+  XSetInputFocus(dpy, PointerRoot, RevertToPointerRoot, CurrentTime);
+  XDeleteProperty(dpy, root, netatom[NetActiveWindow]);
 }
 
-void
-cleanupmon(Monitor *mon)
-{
-	Monitor *m;
+void cleanupmon(Monitor *mon) {
+  Monitor *m;
 
-	if (mon == mons)
-		mons = mons->next;
-	else {
-		for (m = mons; m && m->next != mon; m = m->next);
-		m->next = mon->next;
-	}
-	XUnmapWindow(dpy, mon->barwin);
-	XDestroyWindow(dpy, mon->barwin);
-	free(mon);
+  if (mon == mons)
+    mons = mons->next;
+  else {
+    for (m = mons; m && m->next != mon; m = m->next)
+      ;
+    m->next = mon->next;
+  }
+  XUnmapWindow(dpy, mon->barwin);
+  XDestroyWindow(dpy, mon->barwin);
+  free(mon->pertag);
+  free(mon);
 }
 
-void
-clientmessage(XEvent *e)
-{
-	XWindowAttributes wa;
-	XSetWindowAttributes swa;
-	XClientMessageEvent *cme = &e->xclient;
-	Client *c = wintoclient(cme->window);
+void clientmessage(XEvent *e) {
+  XWindowAttributes wa;
+  XSetWindowAttributes swa;
+  XClientMessageEvent *cme = &e->xclient;
+  Client *c = wintoclient(cme->window);
 
-	if (showsystray && cme->window == systray->win && cme->message_type == netatom[NetSystemTrayOP]) {
-		/* add systray icons */
-		if (cme->data.l[1] == SYSTEM_TRAY_REQUEST_DOCK) {
-			if (!(c = (Client *)calloc(1, sizeof(Client))))
-				die("fatal: could not malloc() %u bytes\n", sizeof(Client));
-			if (!(c->win = cme->data.l[2])) {
-				free(c);
-				return;
-			}
-			c->mon = selmon;
-			c->next = systray->icons;
-			systray->icons = c;
-			if (!XGetWindowAttributes(dpy, c->win, &wa)) {
-				/* use sane defaults */
-				wa.width = bh;
-				wa.height = bh;
-				wa.border_width = 0;
-			}
-			c->x = c->oldx = c->y = c->oldy = 0;
-			c->w = c->oldw = wa.width;
-			c->h = c->oldh = wa.height;
-			c->oldbw = wa.border_width;
-			c->bw = 0;
-			c->isfloating = True;
-			/* reuse tags field as mapped status */
-			c->tags = 1;
-			updatesizehints(c);
-			updatesystrayicongeom(c, wa.width, wa.height);
-			XAddToSaveSet(dpy, c->win);
-			XSelectInput(dpy, c->win, StructureNotifyMask | PropertyChangeMask | ResizeRedirectMask);
-			XReparentWindow(dpy, c->win, systray->win, 0, 0);
-			/* use parents background color */
-			swa.background_pixel  = scheme[SchemeNorm][ColBg].pixel;
-			XChangeWindowAttributes(dpy, c->win, CWBackPixel, &swa);
-			sendevent(c->win, netatom[Xembed], StructureNotifyMask, CurrentTime, XEMBED_EMBEDDED_NOTIFY, 0 , systray->win, XEMBED_EMBEDDED_VERSION);
-			/* FIXME not sure if I have to send these events, too */
-			sendevent(c->win, netatom[Xembed], StructureNotifyMask, CurrentTime, XEMBED_FOCUS_IN, 0 , systray->win, XEMBED_EMBEDDED_VERSION);
-			sendevent(c->win, netatom[Xembed], StructureNotifyMask, CurrentTime, XEMBED_WINDOW_ACTIVATE, 0 , systray->win, XEMBED_EMBEDDED_VERSION);
-			sendevent(c->win, netatom[Xembed], StructureNotifyMask, CurrentTime, XEMBED_MODALITY_ON, 0 , systray->win, XEMBED_EMBEDDED_VERSION);
-			XSync(dpy, False);
-			resizebarwin(selmon);
-			updatesystray();
-			setclientstate(c, NormalState);
-		}
-		return;
-	}
-	if (!c)
-		return;
-	if (cme->message_type == netatom[NetWMState]) {
-		if (cme->data.l[1] == netatom[NetWMFullscreen]
-		|| cme->data.l[2] == netatom[NetWMFullscreen])
-			setfullscreen(c, (cme->data.l[0] == 1 /* _NET_WM_STATE_ADD    */
-				|| (cme->data.l[0] == 2 /* _NET_WM_STATE_TOGGLE */ && !c->isfullscreen)));
-	} else if (cme->message_type == netatom[NetActiveWindow]) {
-		if (c != selmon->sel && !c->isurgent)
-			seturgent(c, 1);
-	}
+  if (showsystray && cme->window == systray->win &&
+      cme->message_type == netatom[NetSystemTrayOP]) {
+    /* add systray icons */
+    if (cme->data.l[1] == SYSTEM_TRAY_REQUEST_DOCK) {
+      if (!(c = (Client *)calloc(1, sizeof(Client))))
+        die("fatal: could not malloc() %u bytes\n", sizeof(Client));
+      if (!(c->win = cme->data.l[2])) {
+        free(c);
+        return;
+      }
+      c->mon = selmon;
+      c->next = systray->icons;
+      systray->icons = c;
+      if (!XGetWindowAttributes(dpy, c->win, &wa)) {
+        /* use sane defaults */
+        wa.width = bh;
+        wa.height = bh;
+        wa.border_width = 0;
+      }
+      c->x = c->oldx = c->y = c->oldy = 0;
+      c->w = c->oldw = wa.width;
+      c->h = c->oldh = wa.height;
+      c->oldbw = wa.border_width;
+      c->bw = 0;
+      c->isfloating = True;
+      /* reuse tags field as mapped status */
+      c->tags = 1;
+      updatesizehints(c);
+      updatesystrayicongeom(c, wa.width, wa.height);
+      XAddToSaveSet(dpy, c->win);
+      XSelectInput(dpy, c->win,
+                   StructureNotifyMask | PropertyChangeMask |
+                       ResizeRedirectMask);
+      XReparentWindow(dpy, c->win, systray->win, 0, 0);
+      /* use parents background color */
+      swa.background_pixel = scheme[SchemeNorm][ColBg].pixel;
+      XChangeWindowAttributes(dpy, c->win, CWBackPixel, &swa);
+      sendevent(c->win, netatom[Xembed], StructureNotifyMask, CurrentTime,
+                XEMBED_EMBEDDED_NOTIFY, 0, systray->win,
+                XEMBED_EMBEDDED_VERSION);
+      /* FIXME not sure if I have to send these events, too */
+      sendevent(c->win, netatom[Xembed], StructureNotifyMask, CurrentTime,
+                XEMBED_FOCUS_IN, 0, systray->win, XEMBED_EMBEDDED_VERSION);
+      sendevent(c->win, netatom[Xembed], StructureNotifyMask, CurrentTime,
+                XEMBED_WINDOW_ACTIVATE, 0, systray->win,
+                XEMBED_EMBEDDED_VERSION);
+      sendevent(c->win, netatom[Xembed], StructureNotifyMask, CurrentTime,
+                XEMBED_MODALITY_ON, 0, systray->win, XEMBED_EMBEDDED_VERSION);
+      XSync(dpy, False);
+      resizebarwin(selmon);
+      updatesystray();
+      setclientstate(c, NormalState);
+    }
+    return;
+  }
+  if (!c)
+    return;
+  if (cme->message_type == netatom[NetWMState]) {
+    if (cme->data.l[1] == netatom[NetWMFullscreen] ||
+        cme->data.l[2] == netatom[NetWMFullscreen])
+      setfullscreen(c, (cme->data.l[0] == 1 /* _NET_WM_STATE_ADD    */
+                        || (cme->data.l[0] == 2 /* _NET_WM_STATE_TOGGLE */ &&
+                            !c->isfullscreen)));
+  } else if (cme->message_type == netatom[NetActiveWindow]) {
+    if (c != selmon->sel && !c->isurgent)
+      seturgent(c, 1);
+  }
 }
 
-void
-configure(Client *c)
-{
-	XConfigureEvent ce;
+void configure(Client *c) {
+  XConfigureEvent ce;
 
-	ce.type = ConfigureNotify;
-	ce.display = dpy;
-	ce.event = c->win;
-	ce.window = c->win;
-	ce.x = c->x;
-	ce.y = c->y;
-	ce.width = c->w;
-	ce.height = c->h;
-	ce.border_width = c->bw;
-	ce.above = None;
-	ce.override_redirect = False;
-	XSendEvent(dpy, c->win, False, StructureNotifyMask, (XEvent *)&ce);
+  ce.type = ConfigureNotify;
+  ce.display = dpy;
+  ce.event = c->win;
+  ce.window = c->win;
+  ce.x = c->x;
+  ce.y = c->y;
+  ce.width = c->w;
+  ce.height = c->h;
+  ce.border_width = c->bw;
+  ce.above = None;
+  ce.override_redirect = False;
+  XSendEvent(dpy, c->win, False, StructureNotifyMask, (XEvent *)&ce);
 }
 
-void
-configurenotify(XEvent *e)
-{
-	Monitor *m;
-	Client *c;
-	XConfigureEvent *ev = &e->xconfigure;
-	int dirty;
+void configurenotify(XEvent *e) {
+  Monitor *m;
+  Client *c;
+  XConfigureEvent *ev = &e->xconfigure;
+  int dirty;
 
-	/* TODO: updategeom handling sucks, needs to be simplified */
-	if (ev->window == root) {
-		dirty = (sw != ev->width || sh != ev->height);
-		sw = ev->width;
-		sh = ev->height;
-		if (updategeom() || dirty) {
-			drw_resize(drw, sw, bh);
-			updatebars();
-			for (m = mons; m; m = m->next) {
-				for (c = m->clients; c; c = c->next)
-					if (c->isfullscreen)
-						resizeclient(c, m->mx, m->my, m->mw, m->mh);
-				resizebarwin(m);
-			}
-			focus(NULL);
-			arrange(NULL);
-		}
-	}
+  /* TODO: updategeom handling sucks, needs to be simplified */
+  if (ev->window == root) {
+    dirty = (sw != ev->width || sh != ev->height);
+    sw = ev->width;
+    sh = ev->height;
+    if (updategeom() || dirty) {
+      drw_resize(drw, sw, bh);
+      updatebars();
+      for (m = mons; m; m = m->next) {
+        for (c = m->clients; c; c = c->next)
+          if (c->isfullscreen)
+            resizeclient(c, m->mx, m->my, m->mw, m->mh);
+        resizebarwin(m);
+      }
+      focus(NULL);
+      arrange(NULL);
+    }
+  }
 }
 
-void
-configurerequest(XEvent *e)
-{
-	Client *c;
-	Monitor *m;
-	XConfigureRequestEvent *ev = &e->xconfigurerequest;
-	XWindowChanges wc;
+void configurerequest(XEvent *e) {
+  Client *c;
+  Monitor *m;
+  XConfigureRequestEvent *ev = &e->xconfigurerequest;
+  XWindowChanges wc;
 
-	if ((c = wintoclient(ev->window))) {
-		if (ev->value_mask & CWBorderWidth)
-			c->bw = ev->border_width;
-		else if (c->isfloating || !selmon->lt[selmon->sellt]->arrange) {
-			m = c->mon;
-			if (ev->value_mask & CWX) {
-				c->oldx = c->x;
-				c->x = m->mx + ev->x;
-			}
-			if (ev->value_mask & CWY) {
-				c->oldy = c->y;
-				c->y = m->my + ev->y;
-			}
-			if (ev->value_mask & CWWidth) {
-				c->oldw = c->w;
-				c->w = ev->width;
-			}
-			if (ev->value_mask & CWHeight) {
-				c->oldh = c->h;
-				c->h = ev->height;
-			}
-			if ((c->x + c->w) > m->mx + m->mw && c->isfloating)
-				c->x = m->mx + (m->mw / 2 - WIDTH(c) / 2); /* center in x direction */
-			if ((c->y + c->h) > m->my + m->mh && c->isfloating)
-				c->y = m->my + (m->mh / 2 - HEIGHT(c) / 2); /* center in y direction */
-			if ((ev->value_mask & (CWX|CWY)) && !(ev->value_mask & (CWWidth|CWHeight)))
-				configure(c);
-			if (ISVISIBLE(c))
-				XMoveResizeWindow(dpy, c->win, c->x, c->y, c->w, c->h);
-		} else
-			configure(c);
-	} else {
-		wc.x = ev->x;
-		wc.y = ev->y;
-		wc.width = ev->width;
-		wc.height = ev->height;
-		wc.border_width = ev->border_width;
-		wc.sibling = ev->above;
-		wc.stack_mode = ev->detail;
-		XConfigureWindow(dpy, ev->window, ev->value_mask, &wc);
-	}
-	XSync(dpy, False);
+  if ((c = wintoclient(ev->window))) {
+    if (ev->value_mask & CWBorderWidth)
+      c->bw = ev->border_width;
+    else if (c->isfloating || !selmon->lt[selmon->sellt]->arrange) {
+      m = c->mon;
+      if (ev->value_mask & CWX) {
+        c->oldx = c->x;
+        c->x = m->mx + ev->x;
+      }
+      if (ev->value_mask & CWY) {
+        c->oldy = c->y;
+        c->y = m->my + ev->y;
+      }
+      if (ev->value_mask & CWWidth) {
+        c->oldw = c->w;
+        c->w = ev->width;
+      }
+      if (ev->value_mask & CWHeight) {
+        c->oldh = c->h;
+        c->h = ev->height;
+      }
+      if ((c->x + c->w) > m->mx + m->mw && c->isfloating)
+        c->x = m->mx + (m->mw / 2 - WIDTH(c) / 2); /* center in x direction */
+      if ((c->y + c->h) > m->my + m->mh && c->isfloating)
+        c->y = m->my + (m->mh / 2 - HEIGHT(c) / 2); /* center in y direction */
+      if ((ev->value_mask & (CWX | CWY)) &&
+          !(ev->value_mask & (CWWidth | CWHeight)))
+        configure(c);
+      if (ISVISIBLE(c))
+        XMoveResizeWindow(dpy, c->win, c->x, c->y, c->w, c->h);
+    } else
+      configure(c);
+  } else {
+    wc.x = ev->x;
+    wc.y = ev->y;
+    wc.width = ev->width;
+    wc.height = ev->height;
+    wc.border_width = ev->border_width;
+    wc.sibling = ev->above;
+    wc.stack_mode = ev->detail;
+    XConfigureWindow(dpy, ev->window, ev->value_mask, &wc);
+  }
+  XSync(dpy, False);
 }
 
-Monitor *
-createmon(void)
-{
-	Monitor *m = ecalloc(1, sizeof(Monitor));
-	m->tagset[0] = m->tagset[1] = 1;
-	m->mfact = mfact;
-	m->nmaster = nmaster;
-	m->showbar = showbar;
-	m->topbar = topbar;
-	m->gappx = gappx;
-	m->lt[0] = &layouts[0];
-	m->lt[1] = &layouts[1 % LENGTH(layouts)];
-	strncpy(m->ltsymbol, layouts[0].symbol, sizeof m->ltsymbol);
-	return m;
+Monitor *createmon(void) {
+  unsigned int i;
+  Monitor *m = ecalloc(1, sizeof(Monitor));
+  m->tagset[0] = m->tagset[1] = 1;
+  m->mfact = mfact;
+  m->nmaster = nmaster;
+  m->showbar = showbar;
+  m->topbar = topbar;
+  m->gappx = gappx;
+  m->lt[0] = &layouts[0];
+  m->lt[1] = &layouts[1 % LENGTH(layouts)];
+  strncpy(m->ltsymbol, layouts[0].symbol, sizeof m->ltsymbol);
+  m->pertag = ecalloc(1, sizeof(Pertag));
+  m->pertag->curtag = m->pertag->prevtag = 1;
+
+  for (i = 0; i <= LENGTH(tags); i++) {
+    m->pertag->nmasters[i] = m->nmaster;
+    m->pertag->mfacts[i] = m->mfact;
+
+    m->pertag->ltidxs[i][0] = m->lt[0];
+    m->pertag->ltidxs[i][1] = m->lt[1];
+    m->pertag->sellts[i] = m->sellt;
+
+    m->pertag->showbars[i] = m->showbar;
+  }
+
+  return m;
 }
 
-void
-destroynotify(XEvent *e)
-{
-	Client *c;
-	XDestroyWindowEvent *ev = &e->xdestroywindow;
+void destroynotify(XEvent *e) {
+  Client *c;
+  XDestroyWindowEvent *ev = &e->xdestroywindow;
 
-	if ((c = wintoclient(ev->window)))
-		unmanage(c, 1);
-	else if ((c = wintosystrayicon(ev->window))) {
-		removesystrayicon(c);
-		resizebarwin(selmon);
-		updatesystray();
-	}
+  if ((c = wintoclient(ev->window)))
+    unmanage(c, 1);
+  else if ((c = wintosystrayicon(ev->window))) {
+    removesystrayicon(c);
+    resizebarwin(selmon);
+    updatesystray();
+  }
 }
 
-void
-detach(Client *c)
-{
-	Client **tc;
+void detach(Client *c) {
+  Client **tc;
 
-	for (tc = &c->mon->clients; *tc && *tc != c; tc = &(*tc)->next);
-	*tc = c->next;
+  for (tc = &c->mon->clients; *tc && *tc != c; tc = &(*tc)->next)
+    ;
+  *tc = c->next;
 }
 
-void
-detachstack(Client *c)
-{
-	Client **tc, *t;
+void detachstack(Client *c) {
+  Client **tc, *t;
 
-	for (tc = &c->mon->stack; *tc && *tc != c; tc = &(*tc)->snext);
-	*tc = c->snext;
+  for (tc = &c->mon->stack; *tc && *tc != c; tc = &(*tc)->snext)
+    ;
+  *tc = c->snext;
 
-	if (c == c->mon->sel) {
-		for (t = c->mon->stack; t && !ISVISIBLE(t); t = t->snext);
-		c->mon->sel = t;
-	}
+  if (c == c->mon->sel) {
+    for (t = c->mon->stack; t && !ISVISIBLE(t); t = t->snext)
+      ;
+    c->mon->sel = t;
+  }
 }
 
-Monitor *
-dirtomon(int dir)
-{
-	Monitor *m = NULL;
+Monitor *dirtomon(int dir) {
+  Monitor *m = NULL;
 
-	if (dir > 0) {
-		if (!(m = selmon->next))
-			m = mons;
-	} else if (selmon == mons)
-		for (m = mons; m->next; m = m->next);
-	else
-		for (m = mons; m->next != selmon; m = m->next);
-	return m;
+  if (dir > 0) {
+    if (!(m = selmon->next))
+      m = mons;
+  } else if (selmon == mons)
+    for (m = mons; m->next; m = m->next)
+      ;
+  else
+    for (m = mons; m->next != selmon; m = m->next)
+      ;
+  return m;
 }
 
-void
-drawbar(Monitor *m)
-{
-	int x, w, sw = 0, stw = 0;
-	int boxs = drw->fonts->h / 9;
-	int boxw = drw->fonts->h / 6 + 2;
-	unsigned int i, occ = 0, urg = 0;
-	Client *c;
+void drawbar(Monitor *m) {
+  int x, w, sw = 0, stw = 0;
+  int boxs = drw->fonts->h / 9;
+  int boxw = drw->fonts->h / 6 + 2;
+  unsigned int i, occ = 0, urg = 0;
+  Client *c;
 
-	if(showsystray && m == systraytomon(m))
-		stw = getsystraywidth();
+  if (showsystray && m == systraytomon(m))
+    stw = getsystraywidth();
 
-	/* draw status first so it can be overdrawn by tags later */
-	if (m == selmon) { /* status is only drawn on selected monitor */
-		drw_setscheme(drw, scheme[SchemeNorm]);
-		sw = TEXTW(stext) - lrpad / 2 + 2; /* 2px right padding */
-		drw_text(drw, m->ww - sw - stw, 0, sw, bh, lrpad / 2 - 2, stext, 0);
-	}
+  /* draw status first so it can be overdrawn by tags later */
+  if (m == selmon) { /* status is only drawn on selected monitor */
+    drw_setscheme(drw, scheme[SchemeNorm]);
+    sw = TEXTW(stext) - lrpad / 2 + 2; /* 2px right padding */
+    drw_text(drw, m->ww - sw - stw, 0, sw, bh, lrpad / 2 - 2, stext, 0);
+  }
 
-	resizebarwin(m);
-	for (c = m->clients; c; c = c->next) {
-		occ |= c->tags;
-		if (c->isurgent)
-			urg |= c->tags;
-	}
-	x = 0;
-	for (i = 0; i < LENGTH(tags); i++) {
-		w = TEXTW(tags[i]);
-		drw_setscheme(drw, scheme[m->tagset[m->seltags] & 1 << i ? SchemeSel : SchemeNorm]);
-		drw_text(drw, x, 0, w, bh, lrpad / 2, tags[i], urg & 1 << i);
-		if (occ & 1 << i)
-			drw_rect(drw, x + boxs, boxs, boxw, boxw,
-				m == selmon && selmon->sel && selmon->sel->tags & 1 << i,
-				urg & 1 << i);
-		x += w;
-	}
-	w = blw = TEXTW(m->ltsymbol);
-	drw_setscheme(drw, scheme[SchemeNorm]);
-	x = drw_text(drw, x, 0, w, bh, lrpad / 2, m->ltsymbol, 0);
+  resizebarwin(m);
+  for (c = m->clients; c; c = c->next) {
+    occ |= c->tags;
+    if (c->isurgent)
+      urg |= c->tags;
+  }
+  x = 0;
+  for (i = 0; i < LENGTH(tags); i++) {
+    w = TEXTW(tags[i]);
+    drw_setscheme(
+        drw, scheme[m->tagset[m->seltags] & 1 << i ? SchemeSel : SchemeNorm]);
+    drw_text(drw, x, 0, w, bh, lrpad / 2, tags[i], urg & 1 << i);
+    if (occ & 1 << i)
+      drw_rect(drw, x + boxs, boxs, boxw, boxw,
+               m == selmon && selmon->sel && selmon->sel->tags & 1 << i,
+               urg & 1 << i);
+    x += w;
+  }
+  w = blw = TEXTW(m->ltsymbol);
+  drw_setscheme(drw, scheme[SchemeNorm]);
+  x = drw_text(drw, x, 0, w, bh, lrpad / 2, m->ltsymbol, 0);
 
-	if ((w = m->ww - sw - stw - x) > bh) {
-		if (m->sel) {
-			drw_setscheme(drw, scheme[m == selmon ? SchemeSel : SchemeNorm]);
-			drw_text(drw, x, 0, w, bh, lrpad / 2, m->sel->name, 0);
-			if (m->sel->isfloating)
-				drw_rect(drw, x + boxs, boxs, boxw, boxw, m->sel->isfixed, 0);
-		} else {
-			drw_setscheme(drw, scheme[SchemeNorm]);
-			drw_rect(drw, x, 0, w, bh, 1, 1);
-		}
-	}
-	drw_map(drw, m->barwin, 0, 0, m->ww - stw, bh);
+  if ((w = m->ww - sw - stw - x) > bh) {
+    if (m->sel) {
+      drw_setscheme(drw, scheme[m == selmon ? SchemeSel : SchemeNorm]);
+      drw_text(drw, x, 0, w, bh, lrpad / 2, m->sel->name, 0);
+      if (m->sel->isfloating)
+        drw_rect(drw, x + boxs, boxs, boxw, boxw, m->sel->isfixed, 0);
+    } else {
+      drw_setscheme(drw, scheme[SchemeNorm]);
+      drw_rect(drw, x, 0, w, bh, 1, 1);
+    }
+  }
+  drw_map(drw, m->barwin, 0, 0, m->ww - stw, bh);
 }
 
-void
-drawbars(void)
-{
-	Monitor *m;
+void drawbars(void) {
+  Monitor *m;
 
-	for (m = mons; m; m = m->next)
-		drawbar(m);
+  for (m = mons; m; m = m->next)
+    drawbar(m);
 }
 
-void
-enternotify(XEvent *e)
-{
-	Client *c;
-	Monitor *m;
-	XCrossingEvent *ev = &e->xcrossing;
+void enternotify(XEvent *e) {
+  Client *c;
+  Monitor *m;
+  XCrossingEvent *ev = &e->xcrossing;
 
-	if ((ev->mode != NotifyNormal || ev->detail == NotifyInferior) && ev->window != root)
-		return;
-	c = wintoclient(ev->window);
-	m = c ? c->mon : wintomon(ev->window);
-	if (m != selmon) {
-		unfocus(selmon->sel, 1);
-		selmon = m;
-	} else if (!c || c == selmon->sel)
-		return;
-	focus(c);
+  if ((ev->mode != NotifyNormal || ev->detail == NotifyInferior) &&
+      ev->window != root)
+    return;
+  c = wintoclient(ev->window);
+  m = c ? c->mon : wintomon(ev->window);
+  if (m != selmon) {
+    unfocus(selmon->sel, 1);
+    selmon = m;
+  } else if (!c || c == selmon->sel)
+    return;
+  focus(c);
 }
 
-void
-expose(XEvent *e)
-{
-	Monitor *m;
-	XExposeEvent *ev = &e->xexpose;
+void expose(XEvent *e) {
+  Monitor *m;
+  XExposeEvent *ev = &e->xexpose;
 
-	if (ev->count == 0 && (m = wintomon(ev->window))) {
-		drawbar(m);
-		if (m == selmon)
-			updatesystray();
-	}
+  if (ev->count == 0 && (m = wintomon(ev->window))) {
+    drawbar(m);
+    if (m == selmon)
+      updatesystray();
+  }
 }
 
-void
-focus(Client *c)
-{
-	if (!c || !ISVISIBLE(c))
-		for (c = selmon->stack; c && !ISVISIBLE(c); c = c->snext);
-	if (selmon->sel && selmon->sel != c)
-		unfocus(selmon->sel, 0);
-	if (c) {
-		if (c->mon != selmon)
-			selmon = c->mon;
-		if (c->isurgent)
-			seturgent(c, 0);
-		detachstack(c);
-		attachstack(c);
-		grabbuttons(c, 1);
-		XSetWindowBorder(dpy, c->win, scheme[SchemeSel][ColBorder].pixel);
-		setfocus(c);
-	} else {
-		XSetInputFocus(dpy, root, RevertToPointerRoot, CurrentTime);
-		XDeleteProperty(dpy, root, netatom[NetActiveWindow]);
-	}
-	selmon->sel = c;
-	drawbars();
+void focus(Client *c) {
+  if (!c || !ISVISIBLE(c))
+    for (c = selmon->stack; c && !ISVISIBLE(c); c = c->snext)
+      ;
+  if (selmon->sel && selmon->sel != c)
+    unfocus(selmon->sel, 0);
+  if (c) {
+    if (c->mon != selmon)
+      selmon = c->mon;
+    if (c->isurgent)
+      seturgent(c, 0);
+    detachstack(c);
+    attachstack(c);
+    grabbuttons(c, 1);
+    XSetWindowBorder(dpy, c->win, scheme[SchemeSel][ColBorder].pixel);
+    setfocus(c);
+  } else {
+    XSetInputFocus(dpy, root, RevertToPointerRoot, CurrentTime);
+    XDeleteProperty(dpy, root, netatom[NetActiveWindow]);
+  }
+  selmon->sel = c;
+  drawbars();
 }
 
 /* there are some broken focus acquiring clients needing extra handling */
-void
-focusin(XEvent *e)
-{
-	XFocusChangeEvent *ev = &e->xfocus;
+void focusin(XEvent *e) {
+  XFocusChangeEvent *ev = &e->xfocus;
 
-	if (selmon->sel && ev->window != selmon->sel->win)
-		setfocus(selmon->sel);
+  if (selmon->sel && ev->window != selmon->sel->win)
+    setfocus(selmon->sel);
 }
 
-void
-focusmon(const Arg *arg)
-{
-	Monitor *m;
+void focusmon(const Arg *arg) {
+  Monitor *m;
 
-	if (!mons->next)
-		return;
-	if ((m = dirtomon(arg->i)) == selmon)
-		return;
-	unfocus(selmon->sel, 0);
-	selmon = m;
-	focus(NULL);
+  if (!mons->next)
+    return;
+  if ((m = dirtomon(arg->i)) == selmon)
+    return;
+  unfocus(selmon->sel, 0);
+  selmon = m;
+  focus(NULL);
 }
 
-void
-focusstack(const Arg *arg)
-{
-	Client *c = NULL, *i;
+void focusstack(const Arg *arg) {
+  Client *c = NULL, *i;
 
-	if (!selmon->sel)
-		return;
-	if (arg->i > 0) {
-		for (c = selmon->sel->next; c && !ISVISIBLE(c); c = c->next);
-		if (!c)
-			for (c = selmon->clients; c && !ISVISIBLE(c); c = c->next);
-	} else {
-		for (i = selmon->clients; i != selmon->sel; i = i->next)
-			if (ISVISIBLE(i))
-				c = i;
-		if (!c)
-			for (; i; i = i->next)
-				if (ISVISIBLE(i))
-					c = i;
-	}
-	if (c) {
-		focus(c);
-		restack(selmon);
-	}
+  if (!selmon->sel)
+    return;
+  if (arg->i > 0) {
+    for (c = selmon->sel->next; c && !ISVISIBLE(c); c = c->next)
+      ;
+    if (!c)
+      for (c = selmon->clients; c && !ISVISIBLE(c); c = c->next)
+        ;
+  } else {
+    for (i = selmon->clients; i != selmon->sel; i = i->next)
+      if (ISVISIBLE(i))
+        c = i;
+    if (!c)
+      for (; i; i = i->next)
+        if (ISVISIBLE(i))
+          c = i;
+  }
+  if (c) {
+    focus(c);
+    restack(selmon);
+  }
 }
 
-Atom
-getatomprop(Client *c, Atom prop)
-{
-	int di;
-	unsigned long dl;
-	unsigned char *p = NULL;
-	Atom da, atom = None;
-	/* FIXME getatomprop should return the number of items and a pointer to
-	 * the stored data instead of this workaround */
-	Atom req = XA_ATOM;
-	if (prop == xatom[XembedInfo])
-		req = xatom[XembedInfo];
+Atom getatomprop(Client *c, Atom prop) {
+  int di;
+  unsigned long dl;
+  unsigned char *p = NULL;
+  Atom da, atom = None;
+  /* FIXME getatomprop should return the number of items and a pointer to
+   * the stored data instead of this workaround */
+  Atom req = XA_ATOM;
+  if (prop == xatom[XembedInfo])
+    req = xatom[XembedInfo];
 
-	if (XGetWindowProperty(dpy, c->win, prop, 0L, sizeof atom, False, req,
-		&da, &di, &dl, &dl, &p) == Success && p) {
-		atom = *(Atom *)p;
-		if (da == xatom[XembedInfo] && dl == 2)
-			atom = ((Atom *)p)[1];
-		XFree(p);
-	}
-	return atom;
+  if (XGetWindowProperty(dpy, c->win, prop, 0L, sizeof atom, False, req, &da,
+                         &di, &dl, &dl, &p) == Success &&
+      p) {
+    atom = *(Atom *)p;
+    if (da == xatom[XembedInfo] && dl == 2)
+      atom = ((Atom *)p)[1];
+    XFree(p);
+  }
+  return atom;
 }
 
-int
-getrootptr(int *x, int *y)
-{
-	int di;
-	unsigned int dui;
-	Window dummy;
+int getrootptr(int *x, int *y) {
+  int di;
+  unsigned int dui;
+  Window dummy;
 
-	return XQueryPointer(dpy, root, &dummy, &dummy, x, y, &di, &di, &dui);
+  return XQueryPointer(dpy, root, &dummy, &dummy, x, y, &di, &di, &dui);
 }
 
-long
-getstate(Window w)
-{
-	int format;
-	long result = -1;
-	unsigned char *p = NULL;
-	unsigned long n, extra;
-	Atom real;
+long getstate(Window w) {
+  int format;
+  long result = -1;
+  unsigned char *p = NULL;
+  unsigned long n, extra;
+  Atom real;
 
-	if (XGetWindowProperty(dpy, w, wmatom[WMState], 0L, 2L, False, wmatom[WMState],
-		&real, &format, &n, &extra, (unsigned char **)&p) != Success)
-		return -1;
-	if (n != 0)
-		result = *p;
-	XFree(p);
-	return result;
+  if (XGetWindowProperty(dpy, w, wmatom[WMState], 0L, 2L, False,
+                         wmatom[WMState], &real, &format, &n, &extra,
+                         (unsigned char **)&p) != Success)
+    return -1;
+  if (n != 0)
+    result = *p;
+  XFree(p);
+  return result;
 }
 
-unsigned int
-getsystraywidth()
-{
-	unsigned int w = 0;
-	Client *i;
-	if(showsystray)
-		for(i = systray->icons; i; w += i->w + systrayspacing, i = i->next) ;
-	return w ? w + systrayspacing : 1;
+unsigned int getsystraywidth() {
+  unsigned int w = 0;
+  Client *i;
+  if (showsystray)
+    for (i = systray->icons; i; w += i->w + systrayspacing, i = i->next)
+      ;
+  return w ? w + systrayspacing : 1;
 }
 
-int
-gettextprop(Window w, Atom atom, char *text, unsigned int size)
-{
-	char **list = NULL;
-	int n;
-	XTextProperty name;
+int gettextprop(Window w, Atom atom, char *text, unsigned int size) {
+  char **list = NULL;
+  int n;
+  XTextProperty name;
 
-	if (!text || size == 0)
-		return 0;
-	text[0] = '\0';
-	if (!XGetTextProperty(dpy, w, &name, atom) || !name.nitems)
-		return 0;
-	if (name.encoding == XA_STRING)
-		strncpy(text, (char *)name.value, size - 1);
-	else {
-		if (XmbTextPropertyToTextList(dpy, &name, &list, &n) >= Success && n > 0 && *list) {
-			strncpy(text, *list, size - 1);
-			XFreeStringList(list);
-		}
-	}
-	text[size - 1] = '\0';
-	XFree(name.value);
-	return 1;
+  if (!text || size == 0)
+    return 0;
+  text[0] = '\0';
+  if (!XGetTextProperty(dpy, w, &name, atom) || !name.nitems)
+    return 0;
+  if (name.encoding == XA_STRING)
+    strncpy(text, (char *)name.value, size - 1);
+  else {
+    if (XmbTextPropertyToTextList(dpy, &name, &list, &n) >= Success && n > 0 &&
+        *list) {
+      strncpy(text, *list, size - 1);
+      XFreeStringList(list);
+    }
+  }
+  text[size - 1] = '\0';
+  XFree(name.value);
+  return 1;
 }
 
-void
-grabbuttons(Client *c, int focused)
-{
-	updatenumlockmask();
-	{
-		unsigned int i, j;
-		unsigned int modifiers[] = { 0, LockMask, numlockmask, numlockmask|LockMask };
-		XUngrabButton(dpy, AnyButton, AnyModifier, c->win);
-		if (!focused)
-			XGrabButton(dpy, AnyButton, AnyModifier, c->win, False,
-				BUTTONMASK, GrabModeSync, GrabModeSync, None, None);
-		for (i = 0; i < LENGTH(buttons); i++)
-			if (buttons[i].click == ClkClientWin)
-				for (j = 0; j < LENGTH(modifiers); j++)
-					XGrabButton(dpy, buttons[i].button,
-						buttons[i].mask | modifiers[j],
-						c->win, False, BUTTONMASK,
-						GrabModeAsync, GrabModeSync, None, None);
-	}
+void grabbuttons(Client *c, int focused) {
+  updatenumlockmask();
+  {
+    unsigned int i, j;
+    unsigned int modifiers[] = {0, LockMask, numlockmask,
+                                numlockmask | LockMask};
+    XUngrabButton(dpy, AnyButton, AnyModifier, c->win);
+    if (!focused)
+      XGrabButton(dpy, AnyButton, AnyModifier, c->win, False, BUTTONMASK,
+                  GrabModeSync, GrabModeSync, None, None);
+    for (i = 0; i < LENGTH(buttons); i++)
+      if (buttons[i].click == ClkClientWin)
+        for (j = 0; j < LENGTH(modifiers); j++)
+          XGrabButton(dpy, buttons[i].button, buttons[i].mask | modifiers[j],
+                      c->win, False, BUTTONMASK, GrabModeAsync, GrabModeSync,
+                      None, None);
+  }
 }
 
-void
-grabkeys(void)
-{
-	updatenumlockmask();
-	{
-		unsigned int i, j;
-		unsigned int modifiers[] = { 0, LockMask, numlockmask, numlockmask|LockMask };
-		KeyCode code;
+void grabkeys(void) {
+  updatenumlockmask();
+  {
+    unsigned int i, j;
+    unsigned int modifiers[] = {0, LockMask, numlockmask,
+                                numlockmask | LockMask};
+    KeyCode code;
 
-		XUngrabKey(dpy, AnyKey, AnyModifier, root);
-		for (i = 0; i < LENGTH(keys); i++)
-			if ((code = XKeysymToKeycode(dpy, keys[i].keysym)))
-				for (j = 0; j < LENGTH(modifiers); j++)
-					XGrabKey(dpy, code, keys[i].mod | modifiers[j], root,
-						True, GrabModeAsync, GrabModeAsync);
-	}
+    XUngrabKey(dpy, AnyKey, AnyModifier, root);
+    for (i = 0; i < LENGTH(keys); i++)
+      if ((code = XKeysymToKeycode(dpy, keys[i].keysym)))
+        for (j = 0; j < LENGTH(modifiers); j++)
+          XGrabKey(dpy, code, keys[i].mod | modifiers[j], root, True,
+                   GrabModeAsync, GrabModeAsync);
+  }
 }
 
-void
-incnmaster(const Arg *arg)
-{
-	selmon->nmaster = MAX(selmon->nmaster + arg->i, 0);
-	arrange(selmon);
+void incnmaster(const Arg *arg) {
+  selmon->nmaster = selmon->pertag->nmasters[selmon->pertag->curtag] =
+      MAX(selmon->nmaster + arg->i, 0);
+  arrange(selmon);
 }
 
 #ifdef XINERAMA
-static int
-isuniquegeom(XineramaScreenInfo *unique, size_t n, XineramaScreenInfo *info)
-{
-	while (n--)
-		if (unique[n].x_org == info->x_org && unique[n].y_org == info->y_org
-		&& unique[n].width == info->width && unique[n].height == info->height)
-			return 0;
-	return 1;
+static int isuniquegeom(XineramaScreenInfo *unique, size_t n,
+                        XineramaScreenInfo *info) {
+  while (n--)
+    if (unique[n].x_org == info->x_org && unique[n].y_org == info->y_org &&
+        unique[n].width == info->width && unique[n].height == info->height)
+      return 0;
+  return 1;
 }
 #endif /* XINERAMA */
 
-void
-keypress(XEvent *e)
-{
-	unsigned int i;
-	KeySym keysym;
-	XKeyEvent *ev;
+void keypress(XEvent *e) {
+  unsigned int i;
+  KeySym keysym;
+  XKeyEvent *ev;
 
-	ev = &e->xkey;
-	keysym = XKeycodeToKeysym(dpy, (KeyCode)ev->keycode, 0);
-	for (i = 0; i < LENGTH(keys); i++)
-		if (keysym == keys[i].keysym
-		&& CLEANMASK(keys[i].mod) == CLEANMASK(ev->state)
-		&& keys[i].func)
-			keys[i].func(&(keys[i].arg));
+  ev = &e->xkey;
+  keysym = XKeycodeToKeysym(dpy, (KeyCode)ev->keycode, 0);
+  for (i = 0; i < LENGTH(keys); i++)
+    if (keysym == keys[i].keysym &&
+        CLEANMASK(keys[i].mod) == CLEANMASK(ev->state) && keys[i].func)
+      keys[i].func(&(keys[i].arg));
 }
 
-void
-killclient(const Arg *arg)
-{
-	if (!selmon->sel)
-		return;
-	if (!sendevent(selmon->sel->win, wmatom[WMDelete], NoEventMask, wmatom[WMDelete], CurrentTime, 0 , 0, 0)) {
-		XGrabServer(dpy);
-		XSetErrorHandler(xerrordummy);
-		XSetCloseDownMode(dpy, DestroyAll);
-		XKillClient(dpy, selmon->sel->win);
-		XSync(dpy, False);
-		XSetErrorHandler(xerror);
-		XUngrabServer(dpy);
-	}
+void killclient(const Arg *arg) {
+  if (!selmon->sel)
+    return;
+  if (!sendevent(selmon->sel->win, wmatom[WMDelete], NoEventMask,
+                 wmatom[WMDelete], CurrentTime, 0, 0, 0)) {
+    XGrabServer(dpy);
+    XSetErrorHandler(xerrordummy);
+    XSetCloseDownMode(dpy, DestroyAll);
+    XKillClient(dpy, selmon->sel->win);
+    XSync(dpy, False);
+    XSetErrorHandler(xerror);
+    XUngrabServer(dpy);
+  }
 }
 
-void
-manage(Window w, XWindowAttributes *wa)
-{
-	Client *c, *t = NULL;
-	Window trans = None;
-	XWindowChanges wc;
+void manage(Window w, XWindowAttributes *wa) {
+  Client *c, *t = NULL;
+  Window trans = None;
+  XWindowChanges wc;
 
-	c = ecalloc(1, sizeof(Client));
-	c->win = w;
-	/* geometry */
-	c->x = c->oldx = wa->x;
-	c->y = c->oldy = wa->y;
-	c->w = c->oldw = wa->width;
-	c->h = c->oldh = wa->height;
-	c->oldbw = wa->border_width;
+  c = ecalloc(1, sizeof(Client));
+  c->win = w;
+  /* geometry */
+  c->x = c->oldx = wa->x;
+  c->y = c->oldy = wa->y;
+  c->w = c->oldw = wa->width;
+  c->h = c->oldh = wa->height;
+  c->oldbw = wa->border_width;
 
-	updatetitle(c);
-	if (XGetTransientForHint(dpy, w, &trans) && (t = wintoclient(trans))) {
-		c->mon = t->mon;
-		c->tags = t->tags;
-	} else {
-		c->mon = selmon;
-		applyrules(c);
-	}
+  updatetitle(c);
+  if (XGetTransientForHint(dpy, w, &trans) && (t = wintoclient(trans))) {
+    c->mon = t->mon;
+    c->tags = t->tags;
+  } else {
+    c->mon = selmon;
+    applyrules(c);
+  }
 
-	if (c->x + WIDTH(c) > c->mon->mx + c->mon->mw)
-		c->x = c->mon->mx + c->mon->mw - WIDTH(c);
-	if (c->y + HEIGHT(c) > c->mon->my + c->mon->mh)
-		c->y = c->mon->my + c->mon->mh - HEIGHT(c);
-	c->x = MAX(c->x, c->mon->mx);
-	/* only fix client y-offset, if the client center might cover the bar */
-	c->y = MAX(c->y, ((c->mon->by == c->mon->my) && (c->x + (c->w / 2) >= c->mon->wx)
-		&& (c->x + (c->w / 2) < c->mon->wx + c->mon->ww)) ? bh : c->mon->my);
-	c->bw = borderpx;
+  if (c->x + WIDTH(c) > c->mon->mx + c->mon->mw)
+    c->x = c->mon->mx + c->mon->mw - WIDTH(c);
+  if (c->y + HEIGHT(c) > c->mon->my + c->mon->mh)
+    c->y = c->mon->my + c->mon->mh - HEIGHT(c);
+  c->x = MAX(c->x, c->mon->mx);
+  /* only fix client y-offset, if the client center might cover the bar */
+  c->y = MAX(c->y,
+             ((c->mon->by == c->mon->my) && (c->x + (c->w / 2) >= c->mon->wx) &&
+              (c->x + (c->w / 2) < c->mon->wx + c->mon->ww))
+                 ? bh
+                 : c->mon->my);
+  c->bw = borderpx;
 
-	wc.border_width = c->bw;
-	XConfigureWindow(dpy, w, CWBorderWidth, &wc);
-	XSetWindowBorder(dpy, w, scheme[SchemeNorm][ColBorder].pixel);
-	configure(c); /* propagates border_width, if size doesn't change */
-	updatewindowtype(c);
-	updatesizehints(c);
-	updatewmhints(c);
-	XSelectInput(dpy, w, EnterWindowMask|FocusChangeMask|PropertyChangeMask|StructureNotifyMask);
-	grabbuttons(c, 0);
-	if (!c->isfloating)
-		c->isfloating = c->oldstate = trans != None || c->isfixed;
-	if (c->isfloating)
-		XRaiseWindow(dpy, c->win);
-	attach(c);
-	attachstack(c);
-	XChangeProperty(dpy, root, netatom[NetClientList], XA_WINDOW, 32, PropModeAppend,
-		(unsigned char *) &(c->win), 1);
-	XMoveResizeWindow(dpy, c->win, c->x + 2 * sw, c->y, c->w, c->h); /* some windows require this */
-	setclientstate(c, NormalState);
-	if (c->mon == selmon)
-		unfocus(selmon->sel, 0);
-	c->mon->sel = c;
-	arrange(c->mon);
-	XMapWindow(dpy, c->win);
-	focus(NULL);
+  wc.border_width = c->bw;
+  XConfigureWindow(dpy, w, CWBorderWidth, &wc);
+  XSetWindowBorder(dpy, w, scheme[SchemeNorm][ColBorder].pixel);
+  configure(c); /* propagates border_width, if size doesn't change */
+  updatewindowtype(c);
+  updatesizehints(c);
+  updatewmhints(c);
+  XSelectInput(dpy, w,
+               EnterWindowMask | FocusChangeMask | PropertyChangeMask |
+                   StructureNotifyMask);
+  grabbuttons(c, 0);
+  if (!c->isfloating)
+    c->isfloating = c->oldstate = trans != None || c->isfixed;
+  if (c->isfloating)
+    XRaiseWindow(dpy, c->win);
+  attach(c);
+  attachstack(c);
+  XChangeProperty(dpy, root, netatom[NetClientList], XA_WINDOW, 32,
+                  PropModeAppend, (unsigned char *)&(c->win), 1);
+  XMoveResizeWindow(dpy, c->win, c->x + 2 * sw, c->y, c->w,
+                    c->h); /* some windows require this */
+  setclientstate(c, NormalState);
+  if (c->mon == selmon)
+    unfocus(selmon->sel, 0);
+  c->mon->sel = c;
+  arrange(c->mon);
+  XMapWindow(dpy, c->win);
+  focus(NULL);
 }
 
-void
-mappingnotify(XEvent *e)
-{
-	XMappingEvent *ev = &e->xmapping;
+void mappingnotify(XEvent *e) {
+  XMappingEvent *ev = &e->xmapping;
 
-	XRefreshKeyboardMapping(ev);
-	if (ev->request == MappingKeyboard)
-		grabkeys();
+  XRefreshKeyboardMapping(ev);
+  if (ev->request == MappingKeyboard)
+    grabkeys();
 }
 
-void
-maprequest(XEvent *e)
-{
-	static XWindowAttributes wa;
-	XMapRequestEvent *ev = &e->xmaprequest;
-	Client *i;
-	if ((i = wintosystrayicon(ev->window))) {
-		sendevent(i->win, netatom[Xembed], StructureNotifyMask, CurrentTime, XEMBED_WINDOW_ACTIVATE, 0, systray->win, XEMBED_EMBEDDED_VERSION);
-		resizebarwin(selmon);
-		updatesystray();
-	}
+void maprequest(XEvent *e) {
+  static XWindowAttributes wa;
+  XMapRequestEvent *ev = &e->xmaprequest;
+  Client *i;
+  if ((i = wintosystrayicon(ev->window))) {
+    sendevent(i->win, netatom[Xembed], StructureNotifyMask, CurrentTime,
+              XEMBED_WINDOW_ACTIVATE, 0, systray->win, XEMBED_EMBEDDED_VERSION);
+    resizebarwin(selmon);
+    updatesystray();
+  }
 
-	if (!XGetWindowAttributes(dpy, ev->window, &wa))
-		return;
-	if (wa.override_redirect)
-		return;
-	if (!wintoclient(ev->window))
-		manage(ev->window, &wa);
+  if (!XGetWindowAttributes(dpy, ev->window, &wa))
+    return;
+  if (wa.override_redirect)
+    return;
+  if (!wintoclient(ev->window))
+    manage(ev->window, &wa);
 }
 
-void
-monocle(Monitor *m)
-{
-	unsigned int n = 0;
-	Client *c;
+void monocle(Monitor *m) {
+  unsigned int n = 0;
+  Client *c;
 
-	for (c = m->clients; c; c = c->next)
-		if (ISVISIBLE(c))
-			n++;
-	if (n > 0) /* override layout symbol */
-		snprintf(m->ltsymbol, sizeof m->ltsymbol, "[%d]", n);
-	for (c = nexttiled(m->clients); c; c = nexttiled(c->next))
-		resize(c, m->wx, m->wy, m->ww - 2 * c->bw, m->wh - 2 * c->bw, 0);
+  for (c = m->clients; c; c = c->next)
+    if (ISVISIBLE(c))
+      n++;
+  if (n > 0) /* override layout symbol */
+    snprintf(m->ltsymbol, sizeof m->ltsymbol, "[%d]", n);
+  for (c = nexttiled(m->clients); c; c = nexttiled(c->next))
+    resize(c, m->wx, m->wy, m->ww - 2 * c->bw, m->wh - 2 * c->bw, 0);
 }
 
-void
-motionnotify(XEvent *e)
-{
-	static Monitor *mon = NULL;
-	Monitor *m;
-	XMotionEvent *ev = &e->xmotion;
+void motionnotify(XEvent *e) {
+  static Monitor *mon = NULL;
+  Monitor *m;
+  XMotionEvent *ev = &e->xmotion;
 
-	if (ev->window != root)
-		return;
-	if ((m = recttomon(ev->x_root, ev->y_root, 1, 1)) != mon && mon) {
-		unfocus(selmon->sel, 1);
-		selmon = m;
-		focus(NULL);
-	}
-	mon = m;
+  if (ev->window != root)
+    return;
+  if ((m = recttomon(ev->x_root, ev->y_root, 1, 1)) != mon && mon) {
+    unfocus(selmon->sel, 1);
+    selmon = m;
+    focus(NULL);
+  }
+  mon = m;
 }
 
-void
-movemouse(const Arg *arg)
-{
-	int x, y, ocx, ocy, nx, ny;
-	Client *c;
-	Monitor *m;
-	XEvent ev;
-	Time lasttime = 0;
+void movemouse(const Arg *arg) {
+  int x, y, ocx, ocy, nx, ny;
+  Client *c;
+  Monitor *m;
+  XEvent ev;
+  Time lasttime = 0;
 
-	if (!(c = selmon->sel))
-		return;
-	if (c->isfullscreen) /* no support moving fullscreen windows by mouse */
-		return;
-	restack(selmon);
-	ocx = c->x;
-	ocy = c->y;
-	if (XGrabPointer(dpy, root, False, MOUSEMASK, GrabModeAsync, GrabModeAsync,
-		None, cursor[CurMove]->cursor, CurrentTime) != GrabSuccess)
-		return;
-	if (!getrootptr(&x, &y))
-		return;
-	do {
-		XMaskEvent(dpy, MOUSEMASK|ExposureMask|SubstructureRedirectMask, &ev);
-		switch(ev.type) {
-		case ConfigureRequest:
-		case Expose:
-		case MapRequest:
-			handler[ev.type](&ev);
-			break;
-		case MotionNotify:
-			if ((ev.xmotion.time - lasttime) <= (1000 / 60))
-				continue;
-			lasttime = ev.xmotion.time;
+  if (!(c = selmon->sel))
+    return;
+  if (c->isfullscreen) /* no support moving fullscreen windows by mouse */
+    return;
+  restack(selmon);
+  ocx = c->x;
+  ocy = c->y;
+  if (XGrabPointer(dpy, root, False, MOUSEMASK, GrabModeAsync, GrabModeAsync,
+                   None, cursor[CurMove]->cursor, CurrentTime) != GrabSuccess)
+    return;
+  if (!getrootptr(&x, &y))
+    return;
+  do {
+    XMaskEvent(dpy, MOUSEMASK | ExposureMask | SubstructureRedirectMask, &ev);
+    switch (ev.type) {
+    case ConfigureRequest:
+    case Expose:
+    case MapRequest:
+      handler[ev.type](&ev);
+      break;
+    case MotionNotify:
+      if ((ev.xmotion.time - lasttime) <= (1000 / 60))
+        continue;
+      lasttime = ev.xmotion.time;
 
-			nx = ocx + (ev.xmotion.x - x);
-			ny = ocy + (ev.xmotion.y - y);
-			if (abs(selmon->wx - nx) < snap)
-				nx = selmon->wx;
-			else if (abs((selmon->wx + selmon->ww) - (nx + WIDTH(c))) < snap)
-				nx = selmon->wx + selmon->ww - WIDTH(c);
-			if (abs(selmon->wy - ny) < snap)
-				ny = selmon->wy;
-			else if (abs((selmon->wy + selmon->wh) - (ny + HEIGHT(c))) < snap)
-				ny = selmon->wy + selmon->wh - HEIGHT(c);
-			if (!c->isfloating && selmon->lt[selmon->sellt]->arrange
-			&& (abs(nx - c->x) > snap || abs(ny - c->y) > snap))
-				togglefloating(NULL);
-			if (!selmon->lt[selmon->sellt]->arrange || c->isfloating)
-				resize(c, nx, ny, c->w, c->h, 1);
-			break;
-		}
-	} while (ev.type != ButtonRelease);
-	XUngrabPointer(dpy, CurrentTime);
-	if ((m = recttomon(c->x, c->y, c->w, c->h)) != selmon) {
-		sendmon(c, m);
-		selmon = m;
-		focus(NULL);
-	}
+      nx = ocx + (ev.xmotion.x - x);
+      ny = ocy + (ev.xmotion.y - y);
+      if (abs(selmon->wx - nx) < snap)
+        nx = selmon->wx;
+      else if (abs((selmon->wx + selmon->ww) - (nx + WIDTH(c))) < snap)
+        nx = selmon->wx + selmon->ww - WIDTH(c);
+      if (abs(selmon->wy - ny) < snap)
+        ny = selmon->wy;
+      else if (abs((selmon->wy + selmon->wh) - (ny + HEIGHT(c))) < snap)
+        ny = selmon->wy + selmon->wh - HEIGHT(c);
+      if (!c->isfloating && selmon->lt[selmon->sellt]->arrange &&
+          (abs(nx - c->x) > snap || abs(ny - c->y) > snap))
+        togglefloating(NULL);
+      if (!selmon->lt[selmon->sellt]->arrange || c->isfloating)
+        resize(c, nx, ny, c->w, c->h, 1);
+      break;
+    }
+  } while (ev.type != ButtonRelease);
+  XUngrabPointer(dpy, CurrentTime);
+  if ((m = recttomon(c->x, c->y, c->w, c->h)) != selmon) {
+    sendmon(c, m);
+    selmon = m;
+    focus(NULL);
+  }
 }
 
-Client *
-nexttiled(Client *c)
-{
-	for (; c && (c->isfloating || !ISVISIBLE(c)); c = c->next);
-	return c;
+Client *nexttiled(Client *c) {
+  for (; c && (c->isfloating || !ISVISIBLE(c)); c = c->next)
+    ;
+  return c;
 }
 
-void
-pop(Client *c)
-{
-	detach(c);
-	attach(c);
-	focus(c);
-	arrange(c->mon);
+void pop(Client *c) {
+  detach(c);
+  attach(c);
+  focus(c);
+  arrange(c->mon);
 }
 
-void
-propertynotify(XEvent *e)
-{
-	Client *c;
-	Window trans;
-	XPropertyEvent *ev = &e->xproperty;
+void propertynotify(XEvent *e) {
+  Client *c;
+  Window trans;
+  XPropertyEvent *ev = &e->xproperty;
 
-	if ((c = wintosystrayicon(ev->window))) {
-		if (ev->atom == XA_WM_NORMAL_HINTS) {
-			updatesizehints(c);
-			updatesystrayicongeom(c, c->w, c->h);
-		}
-		else
-			updatesystrayiconstate(c, ev);
-		resizebarwin(selmon);
-		updatesystray();
-	}
-	if ((ev->window == root) && (ev->atom == XA_WM_NAME))
-		updatestatus();
-	else if (ev->state == PropertyDelete)
-		return; /* ignore */
-	else if ((c = wintoclient(ev->window))) {
-		switch(ev->atom) {
-		default: break;
-		case XA_WM_TRANSIENT_FOR:
-			if (!c->isfloating && (XGetTransientForHint(dpy, c->win, &trans)) &&
-				(c->isfloating = (wintoclient(trans)) != NULL))
-				arrange(c->mon);
-			break;
-		case XA_WM_NORMAL_HINTS:
-			updatesizehints(c);
-			break;
-		case XA_WM_HINTS:
-			updatewmhints(c);
-			drawbars();
-			break;
-		}
-		if (ev->atom == XA_WM_NAME || ev->atom == netatom[NetWMName]) {
-			updatetitle(c);
-			if (c == c->mon->sel)
-				drawbar(c->mon);
-		}
-		if (ev->atom == netatom[NetWMWindowType])
-			updatewindowtype(c);
-	}
+  if ((c = wintosystrayicon(ev->window))) {
+    if (ev->atom == XA_WM_NORMAL_HINTS) {
+      updatesizehints(c);
+      updatesystrayicongeom(c, c->w, c->h);
+    } else
+      updatesystrayiconstate(c, ev);
+    resizebarwin(selmon);
+    updatesystray();
+  }
+  if ((ev->window == root) && (ev->atom == XA_WM_NAME))
+    updatestatus();
+  else if (ev->state == PropertyDelete)
+    return; /* ignore */
+  else if ((c = wintoclient(ev->window))) {
+    switch (ev->atom) {
+    default:
+      break;
+    case XA_WM_TRANSIENT_FOR:
+      if (!c->isfloating && (XGetTransientForHint(dpy, c->win, &trans)) &&
+          (c->isfloating = (wintoclient(trans)) != NULL))
+        arrange(c->mon);
+      break;
+    case XA_WM_NORMAL_HINTS:
+      updatesizehints(c);
+      break;
+    case XA_WM_HINTS:
+      updatewmhints(c);
+      drawbars();
+      break;
+    }
+    if (ev->atom == XA_WM_NAME || ev->atom == netatom[NetWMName]) {
+      updatetitle(c);
+      if (c == c->mon->sel)
+        drawbar(c->mon);
+    }
+    if (ev->atom == netatom[NetWMWindowType])
+      updatewindowtype(c);
+  }
 }
 
-void
-quit(const Arg *arg)
-{
-	running = 0;
+void quit(const Arg *arg) {
+  running = 0;
 }
 
-Monitor *
-recttomon(int x, int y, int w, int h)
-{
-	Monitor *m, *r = selmon;
-	int a, area = 0;
+Monitor *recttomon(int x, int y, int w, int h) {
+  Monitor *m, *r = selmon;
+  int a, area = 0;
 
-	for (m = mons; m; m = m->next)
-		if ((a = INTERSECT(x, y, w, h, m)) > area) {
-			area = a;
-			r = m;
-		}
-	return r;
+  for (m = mons; m; m = m->next)
+    if ((a = INTERSECT(x, y, w, h, m)) > area) {
+      area = a;
+      r = m;
+    }
+  return r;
 }
 
-void
-removesystrayicon(Client *i)
-{
-	Client **ii;
+void removesystrayicon(Client *i) {
+  Client **ii;
 
-	if (!showsystray || !i)
-		return;
-	for (ii = &systray->icons; *ii && *ii != i; ii = &(*ii)->next);
-	if (ii)
-		*ii = i->next;
-	free(i);
+  if (!showsystray || !i)
+    return;
+  for (ii = &systray->icons; *ii && *ii != i; ii = &(*ii)->next)
+    ;
+  if (ii)
+    *ii = i->next;
+  free(i);
 }
 
-
-void
-resize(Client *c, int x, int y, int w, int h, int interact)
-{
-	if (applysizehints(c, &x, &y, &w, &h, interact))
-		resizeclient(c, x, y, w, h);
+void resize(Client *c, int x, int y, int w, int h, int interact) {
+  if (applysizehints(c, &x, &y, &w, &h, interact))
+    resizeclient(c, x, y, w, h);
 }
 
-void
-resizebarwin(Monitor *m) {
-	unsigned int w = m->ww;
-	if (showsystray && m == systraytomon(m))
-		w -= getsystraywidth();
-	XMoveResizeWindow(dpy, m->barwin, m->wx, m->by, w, bh);
+void resizebarwin(Monitor *m) {
+  unsigned int w = m->ww;
+  if (showsystray && m == systraytomon(m))
+    w -= getsystraywidth();
+  XMoveResizeWindow(dpy, m->barwin, m->wx, m->by, w, bh);
 }
 
-void
-resizeclient(Client *c, int x, int y, int w, int h)
-{
-	XWindowChanges wc;
+void resizeclient(Client *c, int x, int y, int w, int h) {
+  XWindowChanges wc;
 
-	c->oldx = c->x; c->x = wc.x = x;
-	c->oldy = c->y; c->y = wc.y = y;
-	c->oldw = c->w; c->w = wc.width = w;
-	c->oldh = c->h; c->h = wc.height = h;
-	wc.border_width = c->bw;
-	XConfigureWindow(dpy, c->win, CWX|CWY|CWWidth|CWHeight|CWBorderWidth, &wc);
-	configure(c);
-	XSync(dpy, False);
+  c->oldx = c->x;
+  c->x = wc.x = x;
+  c->oldy = c->y;
+  c->y = wc.y = y;
+  c->oldw = c->w;
+  c->w = wc.width = w;
+  c->oldh = c->h;
+  c->h = wc.height = h;
+  wc.border_width = c->bw;
+  XConfigureWindow(dpy, c->win, CWX | CWY | CWWidth | CWHeight | CWBorderWidth,
+                   &wc);
+  configure(c);
+  XSync(dpy, False);
 }
 
-void
-resizemouse(const Arg *arg)
-{
-	int ocx, ocy, nw, nh;
-	Client *c;
-	Monitor *m;
-	XEvent ev;
-	Time lasttime = 0;
+void resizemouse(const Arg *arg) {
+  int ocx, ocy, nw, nh;
+  Client *c;
+  Monitor *m;
+  XEvent ev;
+  Time lasttime = 0;
 
-	if (!(c = selmon->sel))
-		return;
-	if (c->isfullscreen) /* no support resizing fullscreen windows by mouse */
-		return;
-	restack(selmon);
-	ocx = c->x;
-	ocy = c->y;
-	if (XGrabPointer(dpy, root, False, MOUSEMASK, GrabModeAsync, GrabModeAsync,
-		None, cursor[CurResize]->cursor, CurrentTime) != GrabSuccess)
-		return;
-	XWarpPointer(dpy, None, c->win, 0, 0, 0, 0, c->w + c->bw - 1, c->h + c->bw - 1);
-	do {
-		XMaskEvent(dpy, MOUSEMASK|ExposureMask|SubstructureRedirectMask, &ev);
-		switch(ev.type) {
-		case ConfigureRequest:
-		case Expose:
-		case MapRequest:
-			handler[ev.type](&ev);
-			break;
-		case MotionNotify:
-			if ((ev.xmotion.time - lasttime) <= (1000 / 60))
-				continue;
-			lasttime = ev.xmotion.time;
+  if (!(c = selmon->sel))
+    return;
+  if (c->isfullscreen) /* no support resizing fullscreen windows by mouse */
+    return;
+  restack(selmon);
+  ocx = c->x;
+  ocy = c->y;
+  if (XGrabPointer(dpy, root, False, MOUSEMASK, GrabModeAsync, GrabModeAsync,
+                   None, cursor[CurResize]->cursor, CurrentTime) != GrabSuccess)
+    return;
+  XWarpPointer(dpy, None, c->win, 0, 0, 0, 0, c->w + c->bw - 1,
+               c->h + c->bw - 1);
+  do {
+    XMaskEvent(dpy, MOUSEMASK | ExposureMask | SubstructureRedirectMask, &ev);
+    switch (ev.type) {
+    case ConfigureRequest:
+    case Expose:
+    case MapRequest:
+      handler[ev.type](&ev);
+      break;
+    case MotionNotify:
+      if ((ev.xmotion.time - lasttime) <= (1000 / 60))
+        continue;
+      lasttime = ev.xmotion.time;
 
-			nw = MAX(ev.xmotion.x - ocx - 2 * c->bw + 1, 1);
-			nh = MAX(ev.xmotion.y - ocy - 2 * c->bw + 1, 1);
-			if (c->mon->wx + nw >= selmon->wx && c->mon->wx + nw <= selmon->wx + selmon->ww
-			&& c->mon->wy + nh >= selmon->wy && c->mon->wy + nh <= selmon->wy + selmon->wh)
-			{
-				if (!c->isfloating && selmon->lt[selmon->sellt]->arrange
-				&& (abs(nw - c->w) > snap || abs(nh - c->h) > snap))
-					togglefloating(NULL);
-			}
-			if (!selmon->lt[selmon->sellt]->arrange || c->isfloating)
-				resize(c, c->x, c->y, nw, nh, 1);
-			break;
-		}
-	} while (ev.type != ButtonRelease);
-	XWarpPointer(dpy, None, c->win, 0, 0, 0, 0, c->w + c->bw - 1, c->h + c->bw - 1);
-	XUngrabPointer(dpy, CurrentTime);
-	while (XCheckMaskEvent(dpy, EnterWindowMask, &ev));
-	if ((m = recttomon(c->x, c->y, c->w, c->h)) != selmon) {
-		sendmon(c, m);
-		selmon = m;
-		focus(NULL);
-	}
+      nw = MAX(ev.xmotion.x - ocx - 2 * c->bw + 1, 1);
+      nh = MAX(ev.xmotion.y - ocy - 2 * c->bw + 1, 1);
+      if (c->mon->wx + nw >= selmon->wx &&
+          c->mon->wx + nw <= selmon->wx + selmon->ww &&
+          c->mon->wy + nh >= selmon->wy &&
+          c->mon->wy + nh <= selmon->wy + selmon->wh) {
+        if (!c->isfloating && selmon->lt[selmon->sellt]->arrange &&
+            (abs(nw - c->w) > snap || abs(nh - c->h) > snap))
+          togglefloating(NULL);
+      }
+      if (!selmon->lt[selmon->sellt]->arrange || c->isfloating)
+        resize(c, c->x, c->y, nw, nh, 1);
+      break;
+    }
+  } while (ev.type != ButtonRelease);
+  XWarpPointer(dpy, None, c->win, 0, 0, 0, 0, c->w + c->bw - 1,
+               c->h + c->bw - 1);
+  XUngrabPointer(dpy, CurrentTime);
+  while (XCheckMaskEvent(dpy, EnterWindowMask, &ev))
+    ;
+  if ((m = recttomon(c->x, c->y, c->w, c->h)) != selmon) {
+    sendmon(c, m);
+    selmon = m;
+    focus(NULL);
+  }
 }
 
-void
-resizerequest(XEvent *e)
-{
-	XResizeRequestEvent *ev = &e->xresizerequest;
-	Client *i;
+void resizerequest(XEvent *e) {
+  XResizeRequestEvent *ev = &e->xresizerequest;
+  Client *i;
 
-	if ((i = wintosystrayicon(ev->window))) {
-		updatesystrayicongeom(i, ev->width, ev->height);
-		resizebarwin(selmon);
-		updatesystray();
-	}
+  if ((i = wintosystrayicon(ev->window))) {
+    updatesystrayicongeom(i, ev->width, ev->height);
+    resizebarwin(selmon);
+    updatesystray();
+  }
 }
 
-void
-restack(Monitor *m)
-{
-	Client *c;
-	XEvent ev;
-	XWindowChanges wc;
+void restack(Monitor *m) {
+  Client *c;
+  XEvent ev;
+  XWindowChanges wc;
 
-	drawbar(m);
-	if (!m->sel)
-		return;
-	if (m->sel->isfloating || !m->lt[m->sellt]->arrange)
-		XRaiseWindow(dpy, m->sel->win);
-	if (m->lt[m->sellt]->arrange) {
-		wc.stack_mode = Below;
-		wc.sibling = m->barwin;
-		for (c = m->stack; c; c = c->snext)
-			if (!c->isfloating && ISVISIBLE(c)) {
-				XConfigureWindow(dpy, c->win, CWSibling|CWStackMode, &wc);
-				wc.sibling = c->win;
-			}
-	}
-	XSync(dpy, False);
-	while (XCheckMaskEvent(dpy, EnterWindowMask, &ev));
+  drawbar(m);
+  if (!m->sel)
+    return;
+  if (m->sel->isfloating || !m->lt[m->sellt]->arrange)
+    XRaiseWindow(dpy, m->sel->win);
+  if (m->lt[m->sellt]->arrange) {
+    wc.stack_mode = Below;
+    wc.sibling = m->barwin;
+    for (c = m->stack; c; c = c->snext)
+      if (!c->isfloating && ISVISIBLE(c)) {
+        XConfigureWindow(dpy, c->win, CWSibling | CWStackMode, &wc);
+        wc.sibling = c->win;
+      }
+  }
+  XSync(dpy, False);
+  while (XCheckMaskEvent(dpy, EnterWindowMask, &ev))
+    ;
 }
 
-void
-run(void)
-{
-	XEvent ev;
-	/* main event loop */
-	XSync(dpy, False);
-	while (running && !XNextEvent(dpy, &ev))
-		if (handler[ev.type])
-			handler[ev.type](&ev); /* call handler */
+void run(void) {
+  XEvent ev;
+  /* main event loop */
+  XSync(dpy, False);
+  while (running && !XNextEvent(dpy, &ev))
+    if (handler[ev.type])
+      handler[ev.type](&ev); /* call handler */
 }
 
-void
-scan(void)
-{
-	unsigned int i, num;
-	Window d1, d2, *wins = NULL;
-	XWindowAttributes wa;
+void scan(void) {
+  unsigned int i, num;
+  Window d1, d2, *wins = NULL;
+  XWindowAttributes wa;
 
-	if (XQueryTree(dpy, root, &d1, &d2, &wins, &num)) {
-		for (i = 0; i < num; i++) {
-			if (!XGetWindowAttributes(dpy, wins[i], &wa)
-			|| wa.override_redirect || XGetTransientForHint(dpy, wins[i], &d1))
-				continue;
-			if (wa.map_state == IsViewable || getstate(wins[i]) == IconicState)
-				manage(wins[i], &wa);
-		}
-		for (i = 0; i < num; i++) { /* now the transients */
-			if (!XGetWindowAttributes(dpy, wins[i], &wa))
-				continue;
-			if (XGetTransientForHint(dpy, wins[i], &d1)
-			&& (wa.map_state == IsViewable || getstate(wins[i]) == IconicState))
-				manage(wins[i], &wa);
-		}
-		if (wins)
-			XFree(wins);
-	}
+  if (XQueryTree(dpy, root, &d1, &d2, &wins, &num)) {
+    for (i = 0; i < num; i++) {
+      if (!XGetWindowAttributes(dpy, wins[i], &wa) || wa.override_redirect ||
+          XGetTransientForHint(dpy, wins[i], &d1))
+        continue;
+      if (wa.map_state == IsViewable || getstate(wins[i]) == IconicState)
+        manage(wins[i], &wa);
+    }
+    for (i = 0; i < num; i++) { /* now the transients */
+      if (!XGetWindowAttributes(dpy, wins[i], &wa))
+        continue;
+      if (XGetTransientForHint(dpy, wins[i], &d1) &&
+          (wa.map_state == IsViewable || getstate(wins[i]) == IconicState))
+        manage(wins[i], &wa);
+    }
+    if (wins)
+      XFree(wins);
+  }
 }
 
-void
-sendmon(Client *c, Monitor *m)
-{
-	if (c->mon == m)
-		return;
-	unfocus(c, 1);
-	detach(c);
-	detachstack(c);
-	c->mon = m;
-	c->tags = m->tagset[m->seltags]; /* assign tags of target monitor */
-	attach(c);
-	attachstack(c);
-	focus(NULL);
-	arrange(NULL);
+void sendmon(Client *c, Monitor *m) {
+  if (c->mon == m)
+    return;
+  unfocus(c, 1);
+  detach(c);
+  detachstack(c);
+  c->mon = m;
+  c->tags = m->tagset[m->seltags]; /* assign tags of target monitor */
+  attach(c);
+  attachstack(c);
+  focus(NULL);
+  arrange(NULL);
 }
 
-void
-setclientstate(Client *c, long state)
-{
-	long data[] = { state, None };
+void setclientstate(Client *c, long state) {
+  long data[] = {state, None};
 
-	XChangeProperty(dpy, c->win, wmatom[WMState], wmatom[WMState], 32,
-		PropModeReplace, (unsigned char *)data, 2);
+  XChangeProperty(dpy, c->win, wmatom[WMState], wmatom[WMState], 32,
+                  PropModeReplace, (unsigned char *)data, 2);
 }
 
-int
-sendevent(Window w, Atom proto, int mask, long d0, long d1, long d2, long d3, long d4)
-{
-	int n;
-	Atom *protocols, mt;
-	int exists = 0;
-	XEvent ev;
+int sendevent(Window w, Atom proto, int mask, long d0, long d1, long d2,
+              long d3, long d4) {
+  int n;
+  Atom *protocols, mt;
+  int exists = 0;
+  XEvent ev;
 
-	if (proto == wmatom[WMTakeFocus] || proto == wmatom[WMDelete]) {
-		mt = wmatom[WMProtocols];
-		if (XGetWMProtocols(dpy, w, &protocols, &n)) {
-			while (!exists && n--)
-				exists = protocols[n] == proto;
-			XFree(protocols);
-		}
-	}
-	else {
-		exists = True;
-		mt = proto;
-	}
-	if (exists) {
-		ev.type = ClientMessage;
-		ev.xclient.window = w;
-		ev.xclient.message_type = mt;
-		ev.xclient.format = 32;
-		ev.xclient.data.l[0] = d0;
-		ev.xclient.data.l[1] = d1;
-		ev.xclient.data.l[2] = d2;
-		ev.xclient.data.l[3] = d3;
-		ev.xclient.data.l[4] = d4;
-		XSendEvent(dpy, w, False, mask, &ev);
-	}
-	return exists;
+  if (proto == wmatom[WMTakeFocus] || proto == wmatom[WMDelete]) {
+    mt = wmatom[WMProtocols];
+    if (XGetWMProtocols(dpy, w, &protocols, &n)) {
+      while (!exists && n--)
+        exists = protocols[n] == proto;
+      XFree(protocols);
+    }
+  } else {
+    exists = True;
+    mt = proto;
+  }
+  if (exists) {
+    ev.type = ClientMessage;
+    ev.xclient.window = w;
+    ev.xclient.message_type = mt;
+    ev.xclient.format = 32;
+    ev.xclient.data.l[0] = d0;
+    ev.xclient.data.l[1] = d1;
+    ev.xclient.data.l[2] = d2;
+    ev.xclient.data.l[3] = d3;
+    ev.xclient.data.l[4] = d4;
+    XSendEvent(dpy, w, False, mask, &ev);
+  }
+  return exists;
 }
 
-void
-setfocus(Client *c)
-{
-	if (!c->neverfocus) {
-		XSetInputFocus(dpy, c->win, RevertToPointerRoot, CurrentTime);
-		XChangeProperty(dpy, root, netatom[NetActiveWindow],
-			XA_WINDOW, 32, PropModeReplace,
-			(unsigned char *) &(c->win), 1);
-	}
-	sendevent(c->win, wmatom[WMTakeFocus], NoEventMask, wmatom[WMTakeFocus], CurrentTime, 0, 0, 0);
+void setfocus(Client *c) {
+  if (!c->neverfocus) {
+    XSetInputFocus(dpy, c->win, RevertToPointerRoot, CurrentTime);
+    XChangeProperty(dpy, root, netatom[NetActiveWindow], XA_WINDOW, 32,
+                    PropModeReplace, (unsigned char *)&(c->win), 1);
+  }
+  sendevent(c->win, wmatom[WMTakeFocus], NoEventMask, wmatom[WMTakeFocus],
+            CurrentTime, 0, 0, 0);
 }
 
-void
-setfullscreen(Client *c, int fullscreen)
-{
-	if (fullscreen && !c->isfullscreen) {
-		XChangeProperty(dpy, c->win, netatom[NetWMState], XA_ATOM, 32,
-			PropModeReplace, (unsigned char*)&netatom[NetWMFullscreen], 1);
-		c->isfullscreen = 1;
-		c->oldstate = c->isfloating;
-		c->oldbw = c->bw;
-		c->bw = 0;
-		c->isfloating = 1;
-		resizeclient(c, c->mon->mx, c->mon->my, c->mon->mw, c->mon->mh);
-		XRaiseWindow(dpy, c->win);
-	} else if (!fullscreen && c->isfullscreen){
-		XChangeProperty(dpy, c->win, netatom[NetWMState], XA_ATOM, 32,
-			PropModeReplace, (unsigned char*)0, 0);
-		c->isfullscreen = 0;
-		c->isfloating = c->oldstate;
-		c->bw = c->oldbw;
-		c->x = c->oldx;
-		c->y = c->oldy;
-		c->w = c->oldw;
-		c->h = c->oldh;
-		resizeclient(c, c->x, c->y, c->w, c->h);
-		arrange(c->mon);
-	}
+void setfullscreen(Client *c, int fullscreen) {
+  if (fullscreen && !c->isfullscreen) {
+    XChangeProperty(dpy, c->win, netatom[NetWMState], XA_ATOM, 32,
+                    PropModeReplace, (unsigned char *)&netatom[NetWMFullscreen],
+                    1);
+    c->isfullscreen = 1;
+    c->oldstate = c->isfloating;
+    c->oldbw = c->bw;
+    c->bw = 0;
+    c->isfloating = 1;
+    resizeclient(c, c->mon->mx, c->mon->my, c->mon->mw, c->mon->mh);
+    XRaiseWindow(dpy, c->win);
+  } else if (!fullscreen && c->isfullscreen) {
+    XChangeProperty(dpy, c->win, netatom[NetWMState], XA_ATOM, 32,
+                    PropModeReplace, (unsigned char *)0, 0);
+    c->isfullscreen = 0;
+    c->isfloating = c->oldstate;
+    c->bw = c->oldbw;
+    c->x = c->oldx;
+    c->y = c->oldy;
+    c->w = c->oldw;
+    c->h = c->oldh;
+    resizeclient(c, c->x, c->y, c->w, c->h);
+    arrange(c->mon);
+  }
 }
 
-void
-setgaps(const Arg *arg)
-{
-	if ((arg->i == 0) || (selmon->gappx + arg->i < 0))
-		selmon->gappx = 0;
-	else
-		selmon->gappx += arg->i;
-	arrange(selmon);
+void setgaps(const Arg *arg) {
+  if ((arg->i == 0) || (selmon->gappx + arg->i < 0))
+    selmon->gappx = 0;
+  else
+    selmon->gappx += arg->i;
+  arrange(selmon);
 }
 
-void
-setlayout(const Arg *arg)
-{
-	if (!arg || !arg->v || arg->v != selmon->lt[selmon->sellt])
-		selmon->sellt ^= 1;
-	if (arg && arg->v)
-		selmon->lt[selmon->sellt] = (Layout *)arg->v;
-	strncpy(selmon->ltsymbol, selmon->lt[selmon->sellt]->symbol, sizeof selmon->ltsymbol);
-	if (selmon->sel)
-		arrange(selmon);
-	else
-		drawbar(selmon);
+void setlayout(const Arg *arg) {
+  if (!arg || !arg->v || arg->v != selmon->lt[selmon->sellt])
+    selmon->sellt = selmon->pertag->sellts[selmon->pertag->curtag] ^= 1;
+  if (arg && arg->v)
+    selmon->lt[selmon->sellt] =
+        selmon->pertag->ltidxs[selmon->pertag->curtag][selmon->sellt] =
+            (Layout *)arg->v;
+  strncpy(selmon->ltsymbol, selmon->lt[selmon->sellt]->symbol,
+          sizeof selmon->ltsymbol);
+  if (selmon->sel)
+    arrange(selmon);
+  else
+    drawbar(selmon);
 }
 
 /* arg > 1.0 will set mfact absolutely */
-void
-setmfact(const Arg *arg)
-{
-	float f;
+void setmfact(const Arg *arg) {
+  float f;
 
-	if (!arg || !selmon->lt[selmon->sellt]->arrange)
-		return;
-	f = arg->f < 1.0 ? arg->f + selmon->mfact : arg->f - 1.0;
-	if (f < 0.1 || f > 0.9)
-		return;
-	selmon->mfact = f;
-	arrange(selmon);
+  if (!arg || !selmon->lt[selmon->sellt]->arrange)
+    return;
+  f = arg->f < 1.0 ? arg->f + selmon->mfact : arg->f - 1.0;
+  if (f < 0.1 || f > 0.9)
+    return;
+  selmon->mfact = selmon->pertag->mfacts[selmon->pertag->curtag] = f;
+  arrange(selmon);
 }
 
-void
-setup(void)
-{
-	int i;
-	XSetWindowAttributes wa;
-	Atom utf8string;
+void setup(void) {
+  int i;
+  XSetWindowAttributes wa;
+  Atom utf8string;
 
-	/* clean up any zombies immediately */
-	sigchld(0);
+  /* clean up any zombies immediately */
+  sigchld(0);
 
-	/* init screen */
-	screen = DefaultScreen(dpy);
-	sw = DisplayWidth(dpy, screen);
-	sh = DisplayHeight(dpy, screen);
-	root = RootWindow(dpy, screen);
-	drw = drw_create(dpy, screen, root, sw, sh);
-	if (!drw_fontset_create(drw, fonts, LENGTH(fonts)))
-		die("no fonts could be loaded.");
-	lrpad = drw->fonts->h;
-	bh = drw->fonts->h + 2;
-	updategeom();
-	/* init atoms */
-	utf8string = XInternAtom(dpy, "UTF8_STRING", False);
-	wmatom[WMProtocols] = XInternAtom(dpy, "WM_PROTOCOLS", False);
-	wmatom[WMDelete] = XInternAtom(dpy, "WM_DELETE_WINDOW", False);
-	wmatom[WMState] = XInternAtom(dpy, "WM_STATE", False);
-	wmatom[WMTakeFocus] = XInternAtom(dpy, "WM_TAKE_FOCUS", False);
-	netatom[NetActiveWindow] = XInternAtom(dpy, "_NET_ACTIVE_WINDOW", False);
-	netatom[NetSupported] = XInternAtom(dpy, "_NET_SUPPORTED", False);
-	netatom[NetSystemTray] = XInternAtom(dpy, "_NET_SYSTEM_TRAY_S0", False);
-	netatom[NetSystemTrayOP] = XInternAtom(dpy, "_NET_SYSTEM_TRAY_OPCODE", False);
-	netatom[NetSystemTrayOrientation] = XInternAtom(dpy, "_NET_SYSTEM_TRAY_ORIENTATION", False);
-	netatom[NetSystemTrayOrientationHorz] = XInternAtom(dpy, "_NET_SYSTEM_TRAY_ORIENTATION_HORZ", False);
-	netatom[NetWMName] = XInternAtom(dpy, "_NET_WM_NAME", False);
-	netatom[NetWMState] = XInternAtom(dpy, "_NET_WM_STATE", False);
-	netatom[NetWMCheck] = XInternAtom(dpy, "_NET_SUPPORTING_WM_CHECK", False);
-	netatom[NetWMFullscreen] = XInternAtom(dpy, "_NET_WM_STATE_FULLSCREEN", False);
-	netatom[NetWMWindowType] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE", False);
-	netatom[NetWMWindowTypeDialog] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_DIALOG", False);
-	netatom[NetClientList] = XInternAtom(dpy, "_NET_CLIENT_LIST", False);
-	xatom[Manager] = XInternAtom(dpy, "MANAGER", False);
-	xatom[Xembed] = XInternAtom(dpy, "_XEMBED", False);
-	xatom[XembedInfo] = XInternAtom(dpy, "_XEMBED_INFO", False);
-	/* init cursors */
-	cursor[CurNormal] = drw_cur_create(drw, XC_left_ptr);
-	cursor[CurResize] = drw_cur_create(drw, XC_sizing);
-	cursor[CurMove] = drw_cur_create(drw, XC_fleur);
-	/* init appearance */
-	scheme = ecalloc(LENGTH(colors), sizeof(Clr *));
-	for (i = 0; i < LENGTH(colors); i++)
-		scheme[i] = drw_scm_create(drw, colors[i], 3);
-	/* init system tray */
-	updatesystray();
-	/* init bars */
-	updatebars();
-	updatestatus();
-	/* supporting window for NetWMCheck */
-	wmcheckwin = XCreateSimpleWindow(dpy, root, 0, 0, 1, 1, 0, 0, 0);
-	XChangeProperty(dpy, wmcheckwin, netatom[NetWMCheck], XA_WINDOW, 32,
-		PropModeReplace, (unsigned char *) &wmcheckwin, 1);
-	XChangeProperty(dpy, wmcheckwin, netatom[NetWMName], utf8string, 8,
-		PropModeReplace, (unsigned char *) "dwm", 3);
-	XChangeProperty(dpy, root, netatom[NetWMCheck], XA_WINDOW, 32,
-		PropModeReplace, (unsigned char *) &wmcheckwin, 1);
-	/* EWMH support per view */
-	XChangeProperty(dpy, root, netatom[NetSupported], XA_ATOM, 32,
-		PropModeReplace, (unsigned char *) netatom, NetLast);
-	XDeleteProperty(dpy, root, netatom[NetClientList]);
-	/* select events */
-	wa.cursor = cursor[CurNormal]->cursor;
-	wa.event_mask = SubstructureRedirectMask|SubstructureNotifyMask
-		|ButtonPressMask|PointerMotionMask|EnterWindowMask
-		|LeaveWindowMask|StructureNotifyMask|PropertyChangeMask;
-	XChangeWindowAttributes(dpy, root, CWEventMask|CWCursor, &wa);
-	XSelectInput(dpy, root, wa.event_mask);
-	grabkeys();
-	focus(NULL);
+  /* init screen */
+  screen = DefaultScreen(dpy);
+  sw = DisplayWidth(dpy, screen);
+  sh = DisplayHeight(dpy, screen);
+  root = RootWindow(dpy, screen);
+  drw = drw_create(dpy, screen, root, sw, sh);
+  if (!drw_fontset_create(drw, fonts, LENGTH(fonts)))
+    die("no fonts could be loaded.");
+  lrpad = drw->fonts->h;
+  bh = drw->fonts->h + 2;
+  updategeom();
+  /* init atoms */
+  utf8string = XInternAtom(dpy, "UTF8_STRING", False);
+  wmatom[WMProtocols] = XInternAtom(dpy, "WM_PROTOCOLS", False);
+  wmatom[WMDelete] = XInternAtom(dpy, "WM_DELETE_WINDOW", False);
+  wmatom[WMState] = XInternAtom(dpy, "WM_STATE", False);
+  wmatom[WMTakeFocus] = XInternAtom(dpy, "WM_TAKE_FOCUS", False);
+  netatom[NetActiveWindow] = XInternAtom(dpy, "_NET_ACTIVE_WINDOW", False);
+  netatom[NetSupported] = XInternAtom(dpy, "_NET_SUPPORTED", False);
+  netatom[NetSystemTray] = XInternAtom(dpy, "_NET_SYSTEM_TRAY_S0", False);
+  netatom[NetSystemTrayOP] = XInternAtom(dpy, "_NET_SYSTEM_TRAY_OPCODE", False);
+  netatom[NetSystemTrayOrientation] =
+      XInternAtom(dpy, "_NET_SYSTEM_TRAY_ORIENTATION", False);
+  netatom[NetSystemTrayOrientationHorz] =
+      XInternAtom(dpy, "_NET_SYSTEM_TRAY_ORIENTATION_HORZ", False);
+  netatom[NetWMName] = XInternAtom(dpy, "_NET_WM_NAME", False);
+  netatom[NetWMState] = XInternAtom(dpy, "_NET_WM_STATE", False);
+  netatom[NetWMCheck] = XInternAtom(dpy, "_NET_SUPPORTING_WM_CHECK", False);
+  netatom[NetWMFullscreen] =
+      XInternAtom(dpy, "_NET_WM_STATE_FULLSCREEN", False);
+  netatom[NetWMWindowType] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE", False);
+  netatom[NetWMWindowTypeDialog] =
+      XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_DIALOG", False);
+  netatom[NetClientList] = XInternAtom(dpy, "_NET_CLIENT_LIST", False);
+  xatom[Manager] = XInternAtom(dpy, "MANAGER", False);
+  xatom[Xembed] = XInternAtom(dpy, "_XEMBED", False);
+  xatom[XembedInfo] = XInternAtom(dpy, "_XEMBED_INFO", False);
+  /* init cursors */
+  cursor[CurNormal] = drw_cur_create(drw, XC_left_ptr);
+  cursor[CurResize] = drw_cur_create(drw, XC_sizing);
+  cursor[CurMove] = drw_cur_create(drw, XC_fleur);
+  /* init appearance */
+  scheme = ecalloc(LENGTH(colors), sizeof(Clr *));
+  for (i = 0; i < LENGTH(colors); i++)
+    scheme[i] = drw_scm_create(drw, colors[i], 3);
+  /* init system tray */
+  updatesystray();
+  /* init bars */
+  updatebars();
+  updatestatus();
+  /* supporting window for NetWMCheck */
+  wmcheckwin = XCreateSimpleWindow(dpy, root, 0, 0, 1, 1, 0, 0, 0);
+  XChangeProperty(dpy, wmcheckwin, netatom[NetWMCheck], XA_WINDOW, 32,
+                  PropModeReplace, (unsigned char *)&wmcheckwin, 1);
+  XChangeProperty(dpy, wmcheckwin, netatom[NetWMName], utf8string, 8,
+                  PropModeReplace, (unsigned char *)"dwm", 3);
+  XChangeProperty(dpy, root, netatom[NetWMCheck], XA_WINDOW, 32,
+                  PropModeReplace, (unsigned char *)&wmcheckwin, 1);
+  /* EWMH support per view */
+  XChangeProperty(dpy, root, netatom[NetSupported], XA_ATOM, 32,
+                  PropModeReplace, (unsigned char *)netatom, NetLast);
+  XDeleteProperty(dpy, root, netatom[NetClientList]);
+  /* select events */
+  wa.cursor = cursor[CurNormal]->cursor;
+  wa.event_mask = SubstructureRedirectMask | SubstructureNotifyMask |
+                  ButtonPressMask | PointerMotionMask | EnterWindowMask |
+                  LeaveWindowMask | StructureNotifyMask | PropertyChangeMask;
+  XChangeWindowAttributes(dpy, root, CWEventMask | CWCursor, &wa);
+  XSelectInput(dpy, root, wa.event_mask);
+  grabkeys();
+  focus(NULL);
 }
 
+void seturgent(Client *c, int urg) {
+  XWMHints *wmh;
 
-void
-seturgent(Client *c, int urg)
-{
-	XWMHints *wmh;
-
-	c->isurgent = urg;
-	if (!(wmh = XGetWMHints(dpy, c->win)))
-		return;
-	wmh->flags = urg ? (wmh->flags | XUrgencyHint) : (wmh->flags & ~XUrgencyHint);
-	XSetWMHints(dpy, c->win, wmh);
-	XFree(wmh);
+  c->isurgent = urg;
+  if (!(wmh = XGetWMHints(dpy, c->win)))
+    return;
+  wmh->flags = urg ? (wmh->flags | XUrgencyHint) : (wmh->flags & ~XUrgencyHint);
+  XSetWMHints(dpy, c->win, wmh);
+  XFree(wmh);
 }
 
-void
-showhide(Client *c)
-{
-	if (!c)
-		return;
-	if (ISVISIBLE(c)) {
-		/* show clients top down */
-		XMoveWindow(dpy, c->win, c->x, c->y);
-		if ((!c->mon->lt[c->mon->sellt]->arrange || c->isfloating) && !c->isfullscreen)
-			resize(c, c->x, c->y, c->w, c->h, 0);
-		showhide(c->snext);
-	} else {
-		/* hide clients bottom up */
-		showhide(c->snext);
-		XMoveWindow(dpy, c->win, WIDTH(c) * -2, c->y);
-	}
+void showhide(Client *c) {
+  if (!c)
+    return;
+  if (ISVISIBLE(c)) {
+    /* show clients top down */
+    XMoveWindow(dpy, c->win, c->x, c->y);
+    if ((!c->mon->lt[c->mon->sellt]->arrange || c->isfloating) &&
+        !c->isfullscreen)
+      resize(c, c->x, c->y, c->w, c->h, 0);
+    showhide(c->snext);
+  } else {
+    /* hide clients bottom up */
+    showhide(c->snext);
+    XMoveWindow(dpy, c->win, WIDTH(c) * -2, c->y);
+  }
 }
 
-void
-sigchld(int unused)
-{
-	if (signal(SIGCHLD, sigchld) == SIG_ERR)
-		die("can't install SIGCHLD handler:");
-	while (0 < waitpid(-1, NULL, WNOHANG));
+void sigchld(int unused) {
+  if (signal(SIGCHLD, sigchld) == SIG_ERR)
+    die("can't install SIGCHLD handler:");
+  while (0 < waitpid(-1, NULL, WNOHANG))
+    ;
 }
 
-void
-spawn(const Arg *arg)
-{
-	if (arg->v == dmenucmd)
-		dmenumon[0] = '0' + selmon->num;
-	if (fork() == 0) {
-		if (dpy)
-			close(ConnectionNumber(dpy));
-		setsid();
-		execvp(((char **)arg->v)[0], (char **)arg->v);
-		fprintf(stderr, "dwm: execvp %s", ((char **)arg->v)[0]);
-		perror(" failed");
-		exit(EXIT_SUCCESS);
-	}
+void spawn(const Arg *arg) {
+  if (arg->v == dmenucmd)
+    dmenumon[0] = '0' + selmon->num;
+  if (fork() == 0) {
+    if (dpy)
+      close(ConnectionNumber(dpy));
+    setsid();
+    execvp(((char **)arg->v)[0], (char **)arg->v);
+    fprintf(stderr, "dwm: execvp %s", ((char **)arg->v)[0]);
+    perror(" failed");
+    exit(EXIT_SUCCESS);
+  }
 }
 
-void
-tag(const Arg *arg)
-{
-	if (selmon->sel && arg->ui & TAGMASK) {
-		selmon->sel->tags = arg->ui & TAGMASK;
-		focus(NULL);
-		arrange(selmon);
-	}
+void tag(const Arg *arg) {
+  if (selmon->sel && arg->ui & TAGMASK) {
+    selmon->sel->tags = arg->ui & TAGMASK;
+    focus(NULL);
+    arrange(selmon);
+  }
 }
 
-void
-tagmon(const Arg *arg)
-{
-	if (!selmon->sel || !mons->next)
-		return;
-	sendmon(selmon->sel, dirtomon(arg->i));
+void tagmon(const Arg *arg) {
+  if (!selmon->sel || !mons->next)
+    return;
+  sendmon(selmon->sel, dirtomon(arg->i));
 }
 
-void
-tile(Monitor *m)
-{
-	unsigned int i, n, h, mw, my, ty;
-	Client *c;
+void tile(Monitor *m) {
+  unsigned int i, n, h, mw, my, ty;
+  Client *c;
 
-	for (n = 0, c = nexttiled(m->clients); c; c = nexttiled(c->next), n++);
-	if (n == 0)
-		return;
+  for (n = 0, c = nexttiled(m->clients); c; c = nexttiled(c->next), n++)
+    ;
+  if (n == 0)
+    return;
 
-	if (n > m->nmaster)
-		mw = m->nmaster ? m->ww * m->mfact : 0;
-	else
-		mw = m->ww - m->gappx; // mw = m->ww;
-	for (i = 0, my = ty = m->gappx, c = nexttiled(m->clients); c; c = nexttiled(c->next), i++) // for (i = my = ty = 0, c = nexttiled(m->clients); c; c = nexttiled(c->next), i++)
-		if (i < m->nmaster) {
-			// h = (m->wh - my) / (MIN(n, m->nmaster) - i);
-			// resize(c, m->wx, m->wy + my, mw - (2*c->bw), h - (2*c->bw), 0);
-			// my += HEIGHT(c);
-			h = (m->wh - my) / (MIN(n, m->nmaster) - i) - m->gappx;
-			resize(c, m->wx + m->gappx, m->wy + my, mw - (2*c->bw) - m->gappx, h - (2*c->bw), 0);
-			if (my + HEIGHT(c) + m->gappx < m->wh)
-				my += HEIGHT(c) + m->gappx;
+  if (n > m->nmaster)
+    mw = m->nmaster ? m->ww * m->mfact : 0;
+  else
+    mw = m->ww - m->gappx; // mw = m->ww;
+  for (i = 0, my = ty = m->gappx, c = nexttiled(m->clients); c;
+       c = nexttiled(c->next),
+      i++) // for (i = my = ty = 0, c = nexttiled(m->clients); c; c =
+           // nexttiled(c->next), i++)
+    if (i < m->nmaster) {
+      // h = (m->wh - my) / (MIN(n, m->nmaster) - i);
+      // resize(c, m->wx, m->wy + my, mw - (2*c->bw), h - (2*c->bw), 0);
+      // my += HEIGHT(c);
+      h = (m->wh - my) / (MIN(n, m->nmaster) - i) - m->gappx;
+      resize(c, m->wx + m->gappx, m->wy + my, mw - (2 * c->bw) - m->gappx,
+             h - (2 * c->bw), 0);
+      if (my + HEIGHT(c) + m->gappx < m->wh)
+        my += HEIGHT(c) + m->gappx;
 
-		} else {
-			// h = (m->wh - ty) / (n - i);
-			// resize(c, m->wx + mw, m->wy + ty, m->ww - mw - (2*c->bw), h - (2*c->bw), 0);
-			// ty += HEIGHT(c);
-			h = (m->wh - ty) / (n - i) - m->gappx;
-			resize(c, m->wx + mw + m->gappx, m->wy + ty, m->ww - mw - (2*c->bw) - 2*m->gappx, h - (2*c->bw), 0);
-			if (ty + HEIGHT(c) + m->gappx < m->wh)
-				ty += HEIGHT(c) + m->gappx;
-
-		}
+    } else {
+      // h = (m->wh - ty) / (n - i);
+      // resize(c, m->wx + mw, m->wy + ty, m->ww - mw - (2*c->bw), h -
+      // (2*c->bw), 0); ty += HEIGHT(c);
+      h = (m->wh - ty) / (n - i) - m->gappx;
+      resize(c, m->wx + mw + m->gappx, m->wy + ty,
+             m->ww - mw - (2 * c->bw) - 2 * m->gappx, h - (2 * c->bw), 0);
+      if (ty + HEIGHT(c) + m->gappx < m->wh)
+        ty += HEIGHT(c) + m->gappx;
+    }
 }
 
-void
-togglebar(const Arg *arg)
-{
-	selmon->showbar = !selmon->showbar;
-	updatebarpos(selmon);
-	resizebarwin(selmon);
-	if (showsystray) {
-		XWindowChanges wc;
-		if (!selmon->showbar)
-			wc.y = -bh;
-		else if (selmon->showbar) {
-			wc.y = 0;
-			if (!selmon->topbar)
-				wc.y = selmon->mh - bh;
-		}
-		XConfigureWindow(dpy, systray->win, CWY, &wc);
-	}
-	arrange(selmon);
+void togglebar(const Arg *arg) {
+  selmon->showbar = selmon->pertag->showbars[selmon->pertag->curtag] =
+      !selmon->showbar;
+  updatebarpos(selmon);
+  resizebarwin(selmon);
+  if (showsystray) {
+    XWindowChanges wc;
+    if (!selmon->showbar)
+      wc.y = -bh;
+    else if (selmon->showbar) {
+      wc.y = 0;
+      if (!selmon->topbar)
+        wc.y = selmon->mh - bh;
+    }
+    XConfigureWindow(dpy, systray->win, CWY, &wc);
+  }
+  arrange(selmon);
 }
 
-void
-togglefloating(const Arg *arg)
-{
-	if (!selmon->sel)
-		return;
-	if (selmon->sel->isfullscreen) /* no support for fullscreen windows */
-		return;
-	selmon->sel->isfloating = !selmon->sel->isfloating || selmon->sel->isfixed;
-	if (selmon->sel->isfloating)
-		resize(selmon->sel, selmon->sel->x, selmon->sel->y,
-			selmon->sel->w, selmon->sel->h, 0);
-	arrange(selmon);
+void togglefloating(const Arg *arg) {
+  if (!selmon->sel)
+    return;
+  if (selmon->sel->isfullscreen) /* no support for fullscreen windows */
+    return;
+  selmon->sel->isfloating = !selmon->sel->isfloating || selmon->sel->isfixed;
+  if (selmon->sel->isfloating)
+    resize(selmon->sel, selmon->sel->x, selmon->sel->y, selmon->sel->w,
+           selmon->sel->h, 0);
+  arrange(selmon);
 }
 
-void
-toggletag(const Arg *arg)
-{
-	unsigned int newtags;
+void toggletag(const Arg *arg) {
+  unsigned int newtags;
 
-	if (!selmon->sel)
-		return;
-	newtags = selmon->sel->tags ^ (arg->ui & TAGMASK);
-	if (newtags) {
-		selmon->sel->tags = newtags;
-		focus(NULL);
-		arrange(selmon);
-	}
+  if (!selmon->sel)
+    return;
+  newtags = selmon->sel->tags ^ (arg->ui & TAGMASK);
+  if (newtags) {
+    selmon->sel->tags = newtags;
+    focus(NULL);
+    arrange(selmon);
+  }
 }
 
-void
-toggleview(const Arg *arg)
-{
-	unsigned int newtagset = selmon->tagset[selmon->seltags] ^ (arg->ui & TAGMASK);
+void toggleview(const Arg *arg) {
+  unsigned int newtagset =
+      selmon->tagset[selmon->seltags] ^ (arg->ui & TAGMASK);
+  int i;
 
-	if (newtagset) {
-		selmon->tagset[selmon->seltags] = newtagset;
-		focus(NULL);
-		arrange(selmon);
-	}
+  if (newtagset) {
+    selmon->tagset[selmon->seltags] = newtagset;
+
+    if (newtagset == ~0) {
+      selmon->pertag->prevtag = selmon->pertag->curtag;
+      selmon->pertag->curtag = 0;
+    }
+
+    /* test if the user did not select the same tag */
+    if (!(newtagset & 1 << (selmon->pertag->curtag - 1))) {
+      selmon->pertag->prevtag = selmon->pertag->curtag;
+      for (i = 0; !(newtagset & 1 << i); i++)
+        ;
+      selmon->pertag->curtag = i + 1;
+    }
+
+    /* apply settings for this view */
+    selmon->nmaster = selmon->pertag->nmasters[selmon->pertag->curtag];
+    selmon->mfact = selmon->pertag->mfacts[selmon->pertag->curtag];
+    selmon->sellt = selmon->pertag->sellts[selmon->pertag->curtag];
+    selmon->lt[selmon->sellt] =
+        selmon->pertag->ltidxs[selmon->pertag->curtag][selmon->sellt];
+    selmon->lt[selmon->sellt ^ 1] =
+        selmon->pertag->ltidxs[selmon->pertag->curtag][selmon->sellt ^ 1];
+
+    if (selmon->showbar != selmon->pertag->showbars[selmon->pertag->curtag])
+      togglebar(NULL);
+
+    focus(NULL);
+    arrange(selmon);
+  }
 }
 
-void
-unfocus(Client *c, int setfocus)
-{
-	if (!c)
-		return;
-	grabbuttons(c, 0);
-	XSetWindowBorder(dpy, c->win, scheme[SchemeNorm][ColBorder].pixel);
-	if (setfocus) {
-		XSetInputFocus(dpy, root, RevertToPointerRoot, CurrentTime);
-		XDeleteProperty(dpy, root, netatom[NetActiveWindow]);
-	}
+void unfocus(Client *c, int setfocus) {
+  if (!c)
+    return;
+  grabbuttons(c, 0);
+  XSetWindowBorder(dpy, c->win, scheme[SchemeNorm][ColBorder].pixel);
+  if (setfocus) {
+    XSetInputFocus(dpy, root, RevertToPointerRoot, CurrentTime);
+    XDeleteProperty(dpy, root, netatom[NetActiveWindow]);
+  }
 }
 
-void
-unmanage(Client *c, int destroyed)
-{
-	Monitor *m = c->mon;
-	XWindowChanges wc;
+void unmanage(Client *c, int destroyed) {
+  Monitor *m = c->mon;
+  XWindowChanges wc;
 
-	detach(c);
-	detachstack(c);
-	if (!destroyed) {
-		wc.border_width = c->oldbw;
-		XGrabServer(dpy); /* avoid race conditions */
-		XSetErrorHandler(xerrordummy);
-		XConfigureWindow(dpy, c->win, CWBorderWidth, &wc); /* restore border */
-		XUngrabButton(dpy, AnyButton, AnyModifier, c->win);
-		setclientstate(c, WithdrawnState);
-		XSync(dpy, False);
-		XSetErrorHandler(xerror);
-		XUngrabServer(dpy);
-	}
-	free(c);
-	focus(NULL);
-	updateclientlist();
-	arrange(m);
+  detach(c);
+  detachstack(c);
+  if (!destroyed) {
+    wc.border_width = c->oldbw;
+    XGrabServer(dpy); /* avoid race conditions */
+    XSetErrorHandler(xerrordummy);
+    XConfigureWindow(dpy, c->win, CWBorderWidth, &wc); /* restore border */
+    XUngrabButton(dpy, AnyButton, AnyModifier, c->win);
+    setclientstate(c, WithdrawnState);
+    XSync(dpy, False);
+    XSetErrorHandler(xerror);
+    XUngrabServer(dpy);
+  }
+  free(c);
+  focus(NULL);
+  updateclientlist();
+  arrange(m);
 }
 
-void
-unmapnotify(XEvent *e)
-{
-	Client *c;
-	XUnmapEvent *ev = &e->xunmap;
+void unmapnotify(XEvent *e) {
+  Client *c;
+  XUnmapEvent *ev = &e->xunmap;
 
-	if ((c = wintoclient(ev->window))) {
-		if (ev->send_event)
-			setclientstate(c, WithdrawnState);
-		else
-			unmanage(c, 0);
-	}
-	else if ((c = wintosystrayicon(ev->window))) {
-		/* KLUDGE! sometimes icons occasionally unmap their windows, but do
-		 * _not_ destroy them. We map those windows back */
-		XMapRaised(dpy, c->win);
-		updatesystray();
-	}
+  if ((c = wintoclient(ev->window))) {
+    if (ev->send_event)
+      setclientstate(c, WithdrawnState);
+    else
+      unmanage(c, 0);
+  } else if ((c = wintosystrayicon(ev->window))) {
+    /* KLUDGE! sometimes icons occasionally unmap their windows, but do
+     * _not_ destroy them. We map those windows back */
+    XMapRaised(dpy, c->win);
+    updatesystray();
+  }
 }
 
-void
-updatebars(void)
-{
-	unsigned int w;
-	Monitor *m;
-	XSetWindowAttributes wa = {
-		.override_redirect = True,
-		.background_pixmap = ParentRelative,
-		.event_mask = ButtonPressMask|ExposureMask
-	};
-	XClassHint ch = {"dwm", "dwm"};
-	for (m = mons; m; m = m->next) {
-		if (m->barwin)
-			continue;
-		w = m->ww;
-		if (showsystray && m == systraytomon(m))
-			w -= getsystraywidth();
-		m->barwin = XCreateWindow(dpy, root, m->wx, m->by, w, bh, 0, DefaultDepth(dpy, screen),
-				CopyFromParent, DefaultVisual(dpy, screen),
-				CWOverrideRedirect|CWBackPixmap|CWEventMask, &wa);
-		XDefineCursor(dpy, m->barwin, cursor[CurNormal]->cursor);
-		if (showsystray && m == systraytomon(m))
-			XMapRaised(dpy, systray->win);
-		XMapRaised(dpy, m->barwin);
-		XSetClassHint(dpy, m->barwin, &ch);
-	}
+void updatebars(void) {
+  unsigned int w;
+  Monitor *m;
+  XSetWindowAttributes wa = {.override_redirect = True,
+                             .background_pixmap = ParentRelative,
+                             .event_mask = ButtonPressMask | ExposureMask};
+  XClassHint ch = {"dwm-bar", "dwm-bar"};
+  for (m = mons; m; m = m->next) {
+    if (m->barwin)
+      continue;
+    w = m->ww;
+    if (showsystray && m == systraytomon(m))
+      w -= getsystraywidth();
+    m->barwin = XCreateWindow(
+        dpy, root, m->wx, m->by, w, bh, 0, DefaultDepth(dpy, screen),
+        CopyFromParent, DefaultVisual(dpy, screen),
+        CWOverrideRedirect | CWBackPixmap | CWEventMask, &wa);
+    XDefineCursor(dpy, m->barwin, cursor[CurNormal]->cursor);
+    if (showsystray && m == systraytomon(m))
+      XMapRaised(dpy, systray->win);
+    XMapRaised(dpy, m->barwin);
+    XSetClassHint(dpy, m->barwin, &ch);
+  }
 }
 
-void
-updatebarpos(Monitor *m)
-{
-	m->wy = m->my;
-	m->wh = m->mh;
-	if (m->showbar) {
-		m->wh -= bh;
-		m->by = m->topbar ? m->wy : m->wy + m->wh;
-		m->wy = m->topbar ? m->wy + bh : m->wy;
-	} else
-		m->by = -bh;
+void updatebarpos(Monitor *m) {
+  m->wy = m->my;
+  m->wh = m->mh;
+  if (m->showbar) {
+    m->wh -= bh;
+    m->by = m->topbar ? m->wy : m->wy + m->wh;
+    m->wy = m->topbar ? m->wy + bh : m->wy;
+  } else
+    m->by = -bh;
 }
 
-void
-updateclientlist()
-{
-	Client *c;
-	Monitor *m;
+void updateclientlist() {
+  Client *c;
+  Monitor *m;
 
-	XDeleteProperty(dpy, root, netatom[NetClientList]);
-	for (m = mons; m; m = m->next)
-		for (c = m->clients; c; c = c->next)
-			XChangeProperty(dpy, root, netatom[NetClientList],
-				XA_WINDOW, 32, PropModeAppend,
-				(unsigned char *) &(c->win), 1);
+  XDeleteProperty(dpy, root, netatom[NetClientList]);
+  for (m = mons; m; m = m->next)
+    for (c = m->clients; c; c = c->next)
+      XChangeProperty(dpy, root, netatom[NetClientList], XA_WINDOW, 32,
+                      PropModeAppend, (unsigned char *)&(c->win), 1);
 }
 
-int
-updategeom(void)
-{
-	int dirty = 0;
+int updategeom(void) {
+  int dirty = 0;
 
 #ifdef XINERAMA
-	if (XineramaIsActive(dpy)) {
-		int i, j, n, nn;
-		Client *c;
-		Monitor *m;
-		XineramaScreenInfo *info = XineramaQueryScreens(dpy, &nn);
-		XineramaScreenInfo *unique = NULL;
+  if (XineramaIsActive(dpy)) {
+    int i, j, n, nn;
+    Client *c;
+    Monitor *m;
+    XineramaScreenInfo *info = XineramaQueryScreens(dpy, &nn);
+    XineramaScreenInfo *unique = NULL;
 
-		for (n = 0, m = mons; m; m = m->next, n++);
-		/* only consider unique geometries as separate screens */
-		unique = ecalloc(nn, sizeof(XineramaScreenInfo));
-		for (i = 0, j = 0; i < nn; i++)
-			if (isuniquegeom(unique, j, &info[i]))
-				memcpy(&unique[j++], &info[i], sizeof(XineramaScreenInfo));
-		XFree(info);
-		nn = j;
-		if (n <= nn) { /* new monitors available */
-			for (i = 0; i < (nn - n); i++) {
-				for (m = mons; m && m->next; m = m->next);
-				if (m)
-					m->next = createmon();
-				else
-					mons = createmon();
-			}
-			for (i = 0, m = mons; i < nn && m; m = m->next, i++)
-				if (i >= n
-				|| unique[i].x_org != m->mx || unique[i].y_org != m->my
-				|| unique[i].width != m->mw || unique[i].height != m->mh)
-				{
-					dirty = 1;
-					m->num = i;
-					m->mx = m->wx = unique[i].x_org;
-					m->my = m->wy = unique[i].y_org;
-					m->mw = m->ww = unique[i].width;
-					m->mh = m->wh = unique[i].height;
-					updatebarpos(m);
-				}
-		} else { /* less monitors available nn < n */
-			for (i = nn; i < n; i++) {
-				for (m = mons; m && m->next; m = m->next);
-				while ((c = m->clients)) {
-					dirty = 1;
-					m->clients = c->next;
-					detachstack(c);
-					c->mon = mons;
-					attach(c);
-					attachstack(c);
-				}
-				if (m == selmon)
-					selmon = mons;
-				cleanupmon(m);
-			}
-		}
-		free(unique);
-	} else
+    for (n = 0, m = mons; m; m = m->next, n++)
+      ;
+    /* only consider unique geometries as separate screens */
+    unique = ecalloc(nn, sizeof(XineramaScreenInfo));
+    for (i = 0, j = 0; i < nn; i++)
+      if (isuniquegeom(unique, j, &info[i]))
+        memcpy(&unique[j++], &info[i], sizeof(XineramaScreenInfo));
+    XFree(info);
+    nn = j;
+    if (n <= nn) { /* new monitors available */
+      for (i = 0; i < (nn - n); i++) {
+        for (m = mons; m && m->next; m = m->next)
+          ;
+        if (m)
+          m->next = createmon();
+        else
+          mons = createmon();
+      }
+      for (i = 0, m = mons; i < nn && m; m = m->next, i++)
+        if (i >= n || unique[i].x_org != m->mx || unique[i].y_org != m->my ||
+            unique[i].width != m->mw || unique[i].height != m->mh) {
+          dirty = 1;
+          m->num = i;
+          m->mx = m->wx = unique[i].x_org;
+          m->my = m->wy = unique[i].y_org;
+          m->mw = m->ww = unique[i].width;
+          m->mh = m->wh = unique[i].height;
+          updatebarpos(m);
+        }
+    } else { /* less monitors available nn < n */
+      for (i = nn; i < n; i++) {
+        for (m = mons; m && m->next; m = m->next)
+          ;
+        while ((c = m->clients)) {
+          dirty = 1;
+          m->clients = c->next;
+          detachstack(c);
+          c->mon = mons;
+          attach(c);
+          attachstack(c);
+        }
+        if (m == selmon)
+          selmon = mons;
+        cleanupmon(m);
+      }
+    }
+    free(unique);
+  } else
 #endif /* XINERAMA */
-	{ /* default monitor setup */
-		if (!mons)
-			mons = createmon();
-		if (mons->mw != sw || mons->mh != sh) {
-			dirty = 1;
-			mons->mw = mons->ww = sw;
-			mons->mh = mons->wh = sh;
-			updatebarpos(mons);
-		}
-	}
-	if (dirty) {
-		selmon = mons;
-		selmon = wintomon(root);
-	}
-	return dirty;
+  {    /* default monitor setup */
+    if (!mons)
+      mons = createmon();
+    if (mons->mw != sw || mons->mh != sh) {
+      dirty = 1;
+      mons->mw = mons->ww = sw;
+      mons->mh = mons->wh = sh;
+      updatebarpos(mons);
+    }
+  }
+  if (dirty) {
+    selmon = mons;
+    selmon = wintomon(root);
+  }
+  return dirty;
 }
 
-void
-updatenumlockmask(void)
-{
-	unsigned int i, j;
-	XModifierKeymap *modmap;
+void updatenumlockmask(void) {
+  unsigned int i, j;
+  XModifierKeymap *modmap;
 
-	numlockmask = 0;
-	modmap = XGetModifierMapping(dpy);
-	for (i = 0; i < 8; i++)
-		for (j = 0; j < modmap->max_keypermod; j++)
-			if (modmap->modifiermap[i * modmap->max_keypermod + j]
-				== XKeysymToKeycode(dpy, XK_Num_Lock))
-				numlockmask = (1 << i);
-	XFreeModifiermap(modmap);
+  numlockmask = 0;
+  modmap = XGetModifierMapping(dpy);
+  for (i = 0; i < 8; i++)
+    for (j = 0; j < modmap->max_keypermod; j++)
+      if (modmap->modifiermap[i * modmap->max_keypermod + j] ==
+          XKeysymToKeycode(dpy, XK_Num_Lock))
+        numlockmask = (1 << i);
+  XFreeModifiermap(modmap);
 }
 
-void
-updatesizehints(Client *c)
-{
-	long msize;
-	XSizeHints size;
+void updatesizehints(Client *c) {
+  long msize;
+  XSizeHints size;
 
-	if (!XGetWMNormalHints(dpy, c->win, &size, &msize))
-		/* size is uninitialized, ensure that size.flags aren't used */
-		size.flags = PSize;
-	if (size.flags & PBaseSize) {
-		c->basew = size.base_width;
-		c->baseh = size.base_height;
-	} else if (size.flags & PMinSize) {
-		c->basew = size.min_width;
-		c->baseh = size.min_height;
-	} else
-		c->basew = c->baseh = 0;
-	if (size.flags & PResizeInc) {
-		c->incw = size.width_inc;
-		c->inch = size.height_inc;
-	} else
-		c->incw = c->inch = 0;
-	if (size.flags & PMaxSize) {
-		c->maxw = size.max_width;
-		c->maxh = size.max_height;
-	} else
-		c->maxw = c->maxh = 0;
-	if (size.flags & PMinSize) {
-		c->minw = size.min_width;
-		c->minh = size.min_height;
-	} else if (size.flags & PBaseSize) {
-		c->minw = size.base_width;
-		c->minh = size.base_height;
-	} else
-		c->minw = c->minh = 0;
-	if (size.flags & PAspect) {
-		c->mina = (float)size.min_aspect.y / size.min_aspect.x;
-		c->maxa = (float)size.max_aspect.x / size.max_aspect.y;
-	} else
-		c->maxa = c->mina = 0.0;
-	c->isfixed = (c->maxw && c->maxh && c->maxw == c->minw && c->maxh == c->minh);
+  if (!XGetWMNormalHints(dpy, c->win, &size, &msize))
+    /* size is uninitialized, ensure that size.flags aren't used */
+    size.flags = PSize;
+  if (size.flags & PBaseSize) {
+    c->basew = size.base_width;
+    c->baseh = size.base_height;
+  } else if (size.flags & PMinSize) {
+    c->basew = size.min_width;
+    c->baseh = size.min_height;
+  } else
+    c->basew = c->baseh = 0;
+  if (size.flags & PResizeInc) {
+    c->incw = size.width_inc;
+    c->inch = size.height_inc;
+  } else
+    c->incw = c->inch = 0;
+  if (size.flags & PMaxSize) {
+    c->maxw = size.max_width;
+    c->maxh = size.max_height;
+  } else
+    c->maxw = c->maxh = 0;
+  if (size.flags & PMinSize) {
+    c->minw = size.min_width;
+    c->minh = size.min_height;
+  } else if (size.flags & PBaseSize) {
+    c->minw = size.base_width;
+    c->minh = size.base_height;
+  } else
+    c->minw = c->minh = 0;
+  if (size.flags & PAspect) {
+    c->mina = (float)size.min_aspect.y / size.min_aspect.x;
+    c->maxa = (float)size.max_aspect.x / size.max_aspect.y;
+  } else
+    c->maxa = c->mina = 0.0;
+  c->isfixed = (c->maxw && c->maxh && c->maxw == c->minw && c->maxh == c->minh);
 }
 
-void
-updatestatus(void)
-{
-	if (!gettextprop(root, XA_WM_NAME, stext, sizeof(stext)))
-		strcpy(stext, "dwm-"VERSION);
-	drawbar(selmon);
-	updatesystray();
+void updatestatus(void) {
+  if (!gettextprop(root, XA_WM_NAME, stext, sizeof(stext)))
+    strcpy(stext, "dwm-" VERSION);
+  drawbar(selmon);
+  updatesystray();
 }
 
-void
-updatesystrayicongeom(Client *i, int w, int h)
-{
-	if (i) {
-		i->h = bh;
-		if (w == h)
-			i->w = bh;
-		else if (h == bh)
-			i->w = w;
-		else
-			i->w = (int) ((float)bh * ((float)w / (float)h));
-		applysizehints(i, &(i->x), &(i->y), &(i->w), &(i->h), False);
-		/* force icons into the systray dimensions if they don't want to */
-		if (i->h > bh) {
-			if (i->w == i->h)
-				i->w = bh;
-			else
-				i->w = (int) ((float)bh * ((float)i->w / (float)i->h));
-			i->h = bh;
-		}
-	}
+void updatesystrayicongeom(Client *i, int w, int h) {
+  if (i) {
+    i->h = bh;
+    if (w == h)
+      i->w = bh;
+    else if (h == bh)
+      i->w = w;
+    else
+      i->w = (int)((float)bh * ((float)w / (float)h));
+    applysizehints(i, &(i->x), &(i->y), &(i->w), &(i->h), False);
+    /* force icons into the systray dimensions if they don't want to */
+    if (i->h > bh) {
+      if (i->w == i->h)
+        i->w = bh;
+      else
+        i->w = (int)((float)bh * ((float)i->w / (float)i->h));
+      i->h = bh;
+    }
+  }
 }
 
-void
-updatesystrayiconstate(Client *i, XPropertyEvent *ev)
-{
-	long flags;
-	int code = 0;
+void updatesystrayiconstate(Client *i, XPropertyEvent *ev) {
+  long flags;
+  int code = 0;
 
-	if (!showsystray || !i || ev->atom != xatom[XembedInfo] ||
-			!(flags = getatomprop(i, xatom[XembedInfo])))
-		return;
+  if (!showsystray || !i || ev->atom != xatom[XembedInfo] ||
+      !(flags = getatomprop(i, xatom[XembedInfo])))
+    return;
 
-	if (flags & XEMBED_MAPPED && !i->tags) {
-		i->tags = 1;
-		code = XEMBED_WINDOW_ACTIVATE;
-		XMapRaised(dpy, i->win);
-		setclientstate(i, NormalState);
-	}
-	else if (!(flags & XEMBED_MAPPED) && i->tags) {
-		i->tags = 0;
-		code = XEMBED_WINDOW_DEACTIVATE;
-		XUnmapWindow(dpy, i->win);
-		setclientstate(i, WithdrawnState);
-	}
-	else
-		return;
-	sendevent(i->win, xatom[Xembed], StructureNotifyMask, CurrentTime, code, 0,
-			systray->win, XEMBED_EMBEDDED_VERSION);
+  if (flags & XEMBED_MAPPED && !i->tags) {
+    i->tags = 1;
+    code = XEMBED_WINDOW_ACTIVATE;
+    XMapRaised(dpy, i->win);
+    setclientstate(i, NormalState);
+  } else if (!(flags & XEMBED_MAPPED) && i->tags) {
+    i->tags = 0;
+    code = XEMBED_WINDOW_DEACTIVATE;
+    XUnmapWindow(dpy, i->win);
+    setclientstate(i, WithdrawnState);
+  } else
+    return;
+  sendevent(i->win, xatom[Xembed], StructureNotifyMask, CurrentTime, code, 0,
+            systray->win, XEMBED_EMBEDDED_VERSION);
 }
 
-void
-updatesystray(void)
-{
-	XSetWindowAttributes wa;
-	XWindowChanges wc;
-	Client *i;
-	Monitor *m = systraytomon(NULL);
-	unsigned int x = m->mx + m->mw;
-	unsigned int w = 1;
+void updatesystray(void) {
+  XSetWindowAttributes wa;
+  XWindowChanges wc;
+  Client *i;
+  Monitor *m = systraytomon(NULL);
+  unsigned int x = m->mx + m->mw;
+  unsigned int w = 1;
 
-	if (!showsystray)
-		return;
-	if (!systray) {
-		/* init systray */
-		if (!(systray = (Systray *)calloc(1, sizeof(Systray))))
-			die("fatal: could not malloc() %u bytes\n", sizeof(Systray));
-		systray->win = XCreateSimpleWindow(dpy, root, x, m->by, w, bh, 0, 0, scheme[SchemeSel][ColBg].pixel);
-		wa.event_mask        = ButtonPressMask | ExposureMask;
-		wa.override_redirect = True;
-		wa.background_pixel  = scheme[SchemeNorm][ColBg].pixel;
-		XSelectInput(dpy, systray->win, SubstructureNotifyMask);
-		XChangeProperty(dpy, systray->win, netatom[NetSystemTrayOrientation], XA_CARDINAL, 32,
-				PropModeReplace, (unsigned char *)&netatom[NetSystemTrayOrientationHorz], 1);
-		XChangeWindowAttributes(dpy, systray->win, CWEventMask|CWOverrideRedirect|CWBackPixel, &wa);
-		XMapRaised(dpy, systray->win);
-		XSetSelectionOwner(dpy, netatom[NetSystemTray], systray->win, CurrentTime);
-		if (XGetSelectionOwner(dpy, netatom[NetSystemTray]) == systray->win) {
-			sendevent(root, xatom[Manager], StructureNotifyMask, CurrentTime, netatom[NetSystemTray], systray->win, 0, 0);
-			XSync(dpy, False);
-		}
-		else {
-			fprintf(stderr, "dwm: unable to obtain system tray.\n");
-			free(systray);
-			systray = NULL;
-			return;
-		}
-	}
-	for (w = 0, i = systray->icons; i; i = i->next) {
-		/* make sure the background color stays the same */
-		wa.background_pixel  = scheme[SchemeNorm][ColBg].pixel;
-		XChangeWindowAttributes(dpy, i->win, CWBackPixel, &wa);
-		XMapRaised(dpy, i->win);
-		w += systrayspacing;
-		i->x = w;
-		XMoveResizeWindow(dpy, i->win, i->x, 0, i->w, i->h);
-		w += i->w;
-		if (i->mon != m)
-			i->mon = m;
-	}
-	w = w ? w + systrayspacing : 1;
-	x -= w;
-	XMoveResizeWindow(dpy, systray->win, x, m->by, w, bh);
-	wc.x = x; wc.y = m->by; wc.width = w; wc.height = bh;
-	wc.stack_mode = Above; wc.sibling = m->barwin;
-	XConfigureWindow(dpy, systray->win, CWX|CWY|CWWidth|CWHeight|CWSibling|CWStackMode, &wc);
-	XMapWindow(dpy, systray->win);
-	XMapSubwindows(dpy, systray->win);
-	/* redraw background */
-	XSetForeground(dpy, drw->gc, scheme[SchemeNorm][ColBg].pixel);
-	XFillRectangle(dpy, systray->win, drw->gc, 0, 0, w, bh);
-	XSync(dpy, False);
+  if (!showsystray)
+    return;
+  if (!systray) {
+    /* init systray */
+    if (!(systray = (Systray *)calloc(1, sizeof(Systray))))
+      die("fatal: could not malloc() %u bytes\n", sizeof(Systray));
+    systray->win = XCreateSimpleWindow(dpy, root, x, m->by, w, bh, 0, 0,
+                                       scheme[SchemeSel][ColBg].pixel);
+    wa.event_mask = ButtonPressMask | ExposureMask;
+    wa.override_redirect = True;
+    wa.background_pixel = scheme[SchemeNorm][ColBg].pixel;
+    XSelectInput(dpy, systray->win, SubstructureNotifyMask);
+    XChangeProperty(dpy, systray->win, netatom[NetSystemTrayOrientation],
+                    XA_CARDINAL, 32, PropModeReplace,
+                    (unsigned char *)&netatom[NetSystemTrayOrientationHorz], 1);
+    XChangeWindowAttributes(
+        dpy, systray->win, CWEventMask | CWOverrideRedirect | CWBackPixel, &wa);
+    XMapRaised(dpy, systray->win);
+    XSetSelectionOwner(dpy, netatom[NetSystemTray], systray->win, CurrentTime);
+    if (XGetSelectionOwner(dpy, netatom[NetSystemTray]) == systray->win) {
+      sendevent(root, xatom[Manager], StructureNotifyMask, CurrentTime,
+                netatom[NetSystemTray], systray->win, 0, 0);
+      XSync(dpy, False);
+    } else {
+      fprintf(stderr, "dwm: unable to obtain system tray.\n");
+      free(systray);
+      systray = NULL;
+      return;
+    }
+  }
+  for (w = 0, i = systray->icons; i; i = i->next) {
+    /* make sure the background color stays the same */
+    wa.background_pixel = scheme[SchemeNorm][ColBg].pixel;
+    XChangeWindowAttributes(dpy, i->win, CWBackPixel, &wa);
+    XMapRaised(dpy, i->win);
+    w += systrayspacing;
+    i->x = w;
+    XMoveResizeWindow(dpy, i->win, i->x, 0, i->w, i->h);
+    w += i->w;
+    if (i->mon != m)
+      i->mon = m;
+  }
+  w = w ? w + systrayspacing : 1;
+  x -= w;
+  XMoveResizeWindow(dpy, systray->win, x, m->by, w, bh);
+  wc.x = x;
+  wc.y = m->by;
+  wc.width = w;
+  wc.height = bh;
+  wc.stack_mode = Above;
+  wc.sibling = m->barwin;
+  XConfigureWindow(dpy, systray->win,
+                   CWX | CWY | CWWidth | CWHeight | CWSibling | CWStackMode,
+                   &wc);
+  XMapWindow(dpy, systray->win);
+  XMapSubwindows(dpy, systray->win);
+  /* redraw background */
+  XSetForeground(dpy, drw->gc, scheme[SchemeNorm][ColBg].pixel);
+  XFillRectangle(dpy, systray->win, drw->gc, 0, 0, w, bh);
+  XSync(dpy, False);
 }
 
-void
-updatetitle(Client *c)
-{
-	if (!gettextprop(c->win, netatom[NetWMName], c->name, sizeof c->name))
-		gettextprop(c->win, XA_WM_NAME, c->name, sizeof c->name);
-	if (c->name[0] == '\0') /* hack to mark broken clients */
-		strcpy(c->name, broken);
+void updatetitle(Client *c) {
+  if (!gettextprop(c->win, netatom[NetWMName], c->name, sizeof c->name))
+    gettextprop(c->win, XA_WM_NAME, c->name, sizeof c->name);
+  if (c->name[0] == '\0') /* hack to mark broken clients */
+    strcpy(c->name, broken);
 }
 
-void
-updatewindowtype(Client *c)
-{
-	Atom state = getatomprop(c, netatom[NetWMState]);
-	Atom wtype = getatomprop(c, netatom[NetWMWindowType]);
+void updatewindowtype(Client *c) {
+  Atom state = getatomprop(c, netatom[NetWMState]);
+  Atom wtype = getatomprop(c, netatom[NetWMWindowType]);
 
-	if (state == netatom[NetWMFullscreen])
-		setfullscreen(c, 1);
-	if (wtype == netatom[NetWMWindowTypeDialog])
-		c->isfloating = 1;
+  if (state == netatom[NetWMFullscreen])
+    setfullscreen(c, 1);
+  if (wtype == netatom[NetWMWindowTypeDialog])
+    c->isfloating = 1;
 }
 
-void
-updatewmhints(Client *c)
-{
-	XWMHints *wmh;
+void updatewmhints(Client *c) {
+  XWMHints *wmh;
 
-	if ((wmh = XGetWMHints(dpy, c->win))) {
-		if (c == selmon->sel && wmh->flags & XUrgencyHint) {
-			wmh->flags &= ~XUrgencyHint;
-			XSetWMHints(dpy, c->win, wmh);
-		} else
-			c->isurgent = (wmh->flags & XUrgencyHint) ? 1 : 0;
-		if (wmh->flags & InputHint)
-			c->neverfocus = !wmh->input;
-		else
-			c->neverfocus = 0;
-		XFree(wmh);
-	}
+  if ((wmh = XGetWMHints(dpy, c->win))) {
+    if (c == selmon->sel && wmh->flags & XUrgencyHint) {
+      wmh->flags &= ~XUrgencyHint;
+      XSetWMHints(dpy, c->win, wmh);
+    } else
+      c->isurgent = (wmh->flags & XUrgencyHint) ? 1 : 0;
+    if (wmh->flags & InputHint)
+      c->neverfocus = !wmh->input;
+    else
+      c->neverfocus = 0;
+    XFree(wmh);
+  }
 }
 
-void
-view(const Arg *arg)
-{
-	if ((arg->ui & TAGMASK) == selmon->tagset[selmon->seltags])
-		return;
-	selmon->seltags ^= 1; /* toggle sel tagset */
-	if (arg->ui & TAGMASK)
-		selmon->tagset[selmon->seltags] = arg->ui & TAGMASK;
-	focus(NULL);
-	arrange(selmon);
+void view(const Arg *arg) {
+  int i;
+  unsigned int tmptag;
+
+  if ((arg->ui & TAGMASK) == selmon->tagset[selmon->seltags])
+    return;
+  selmon->seltags ^= 1; /* toggle sel tagset */
+  if (arg->ui & TAGMASK) {
+    selmon->tagset[selmon->seltags] = arg->ui & TAGMASK;
+    selmon->pertag->prevtag = selmon->pertag->curtag;
+
+    if (arg->ui == ~0)
+      selmon->pertag->curtag = 0;
+    else {
+      for (i = 0; !(arg->ui & 1 << i); i++)
+        ;
+      selmon->pertag->curtag = i + 1;
+    }
+  } else {
+    tmptag = selmon->pertag->prevtag;
+    selmon->pertag->prevtag = selmon->pertag->curtag;
+    selmon->pertag->curtag = tmptag;
+  }
+
+  selmon->nmaster = selmon->pertag->nmasters[selmon->pertag->curtag];
+  selmon->mfact = selmon->pertag->mfacts[selmon->pertag->curtag];
+  selmon->sellt = selmon->pertag->sellts[selmon->pertag->curtag];
+  selmon->lt[selmon->sellt] =
+      selmon->pertag->ltidxs[selmon->pertag->curtag][selmon->sellt];
+  selmon->lt[selmon->sellt ^ 1] =
+      selmon->pertag->ltidxs[selmon->pertag->curtag][selmon->sellt ^ 1];
+
+  if (selmon->showbar != selmon->pertag->showbars[selmon->pertag->curtag])
+    togglebar(NULL);
+
+  focus(NULL);
+  arrange(selmon);
 }
 
-Client *
-wintoclient(Window w)
-{
-	Client *c;
-	Monitor *m;
+Client *wintoclient(Window w) {
+  Client *c;
+  Monitor *m;
 
-	for (m = mons; m; m = m->next)
-		for (c = m->clients; c; c = c->next)
-			if (c->win == w)
-				return c;
-	return NULL;
+  for (m = mons; m; m = m->next)
+    for (c = m->clients; c; c = c->next)
+      if (c->win == w)
+        return c;
+  return NULL;
 }
 
-Client *
-wintosystrayicon(Window w) {
-	Client *i = NULL;
+Client *wintosystrayicon(Window w) {
+  Client *i = NULL;
 
-	if (!showsystray || !w)
-		return i;
-	for (i = systray->icons; i && i->win != w; i = i->next) ;
-	return i;
+  if (!showsystray || !w)
+    return i;
+  for (i = systray->icons; i && i->win != w; i = i->next)
+    ;
+  return i;
 }
 
-Monitor *
-wintomon(Window w)
-{
-	int x, y;
-	Client *c;
-	Monitor *m;
+Monitor *wintomon(Window w) {
+  int x, y;
+  Client *c;
+  Monitor *m;
 
-	if (w == root && getrootptr(&x, &y))
-		return recttomon(x, y, 1, 1);
-	for (m = mons; m; m = m->next)
-		if (w == m->barwin)
-			return m;
-	if ((c = wintoclient(w)))
-		return c->mon;
-	return selmon;
+  if (w == root && getrootptr(&x, &y))
+    return recttomon(x, y, 1, 1);
+  for (m = mons; m; m = m->next)
+    if (w == m->barwin)
+      return m;
+  if ((c = wintoclient(w)))
+    return c->mon;
+  return selmon;
 }
 
 /* There's no way to check accesses to destroyed windows, thus those cases are
  * ignored (especially on UnmapNotify's). Other types of errors call Xlibs
  * default error handler, which may call exit. */
-int
-xerror(Display *dpy, XErrorEvent *ee)
-{
-	if (ee->error_code == BadWindow
-	|| (ee->request_code == X_SetInputFocus && ee->error_code == BadMatch)
-	|| (ee->request_code == X_PolyText8 && ee->error_code == BadDrawable)
-	|| (ee->request_code == X_PolyFillRectangle && ee->error_code == BadDrawable)
-	|| (ee->request_code == X_PolySegment && ee->error_code == BadDrawable)
-	|| (ee->request_code == X_ConfigureWindow && ee->error_code == BadMatch)
-	|| (ee->request_code == X_GrabButton && ee->error_code == BadAccess)
-	|| (ee->request_code == X_GrabKey && ee->error_code == BadAccess)
-	|| (ee->request_code == X_CopyArea && ee->error_code == BadDrawable))
-		return 0;
-	fprintf(stderr, "dwm: fatal error: request code=%d, error code=%d\n",
-		ee->request_code, ee->error_code);
-	return xerrorxlib(dpy, ee); /* may call exit */
+int xerror(Display *dpy, XErrorEvent *ee) {
+  if (ee->error_code == BadWindow ||
+      (ee->request_code == X_SetInputFocus && ee->error_code == BadMatch) ||
+      (ee->request_code == X_PolyText8 && ee->error_code == BadDrawable) ||
+      (ee->request_code == X_PolyFillRectangle &&
+       ee->error_code == BadDrawable) ||
+      (ee->request_code == X_PolySegment && ee->error_code == BadDrawable) ||
+      (ee->request_code == X_ConfigureWindow && ee->error_code == BadMatch) ||
+      (ee->request_code == X_GrabButton && ee->error_code == BadAccess) ||
+      (ee->request_code == X_GrabKey && ee->error_code == BadAccess) ||
+      (ee->request_code == X_CopyArea && ee->error_code == BadDrawable))
+    return 0;
+  fprintf(stderr, "dwm: fatal error: request code=%d, error code=%d\n",
+          ee->request_code, ee->error_code);
+  return xerrorxlib(dpy, ee); /* may call exit */
 }
 
-int
-xerrordummy(Display *dpy, XErrorEvent *ee)
-{
-	return 0;
+int xerrordummy(Display *dpy, XErrorEvent *ee) {
+  return 0;
 }
 
 /* Startup Error handler to check if another window manager
  * is already running. */
-int
-xerrorstart(Display *dpy, XErrorEvent *ee)
-{
-	die("dwm: another window manager is already running");
-	return -1;
+int xerrorstart(Display *dpy, XErrorEvent *ee) {
+  die("dwm: another window manager is already running");
+  return -1;
 }
 
-Monitor *
-systraytomon(Monitor *m) {
-	Monitor *t;
-	int i, n;
-	if(!systraypinning) {
-		if(!m)
-			return selmon;
-		return m == selmon ? m : NULL;
-	}
-	for(n = 1, t = mons; t && t->next; n++, t = t->next) ;
-	for(i = 1, t = mons; t && t->next && i < systraypinning; i++, t = t->next) ;
-	if(systraypinningfailfirst && n < systraypinning)
-		return mons;
-	return t;
+Monitor *systraytomon(Monitor *m) {
+  Monitor *t;
+  int i, n;
+  if (!systraypinning) {
+    if (!m)
+      return selmon;
+    return m == selmon ? m : NULL;
+  }
+  for (n = 1, t = mons; t && t->next; n++, t = t->next)
+    ;
+  for (i = 1, t = mons; t && t->next && i < systraypinning; i++, t = t->next)
+    ;
+  if (systraypinningfailfirst && n < systraypinning)
+    return mons;
+  return t;
 }
 
-void
-zoom(const Arg *arg)
-{
-	Client *c = selmon->sel;
+void zoom(const Arg *arg) {
+  Client *c = selmon->sel;
 
-	if (!selmon->lt[selmon->sellt]->arrange
-	|| (selmon->sel && selmon->sel->isfloating))
-		return;
-	if (c == nexttiled(selmon->clients))
-		if (!c || !(c = nexttiled(c->next)))
-			return;
-	pop(c);
+  if (!selmon->lt[selmon->sellt]->arrange ||
+      (selmon->sel && selmon->sel->isfloating))
+    return;
+  if (c == nexttiled(selmon->clients))
+    if (!c || !(c = nexttiled(c->next)))
+      return;
+  pop(c);
 }
 
-int
-main(int argc, char *argv[])
-{
-	if (argc == 2 && !strcmp("-v", argv[1]))
-		die("dwm-"VERSION);
-	else if (argc != 1)
-		die("usage: dwm [-v]");
-	if (!setlocale(LC_CTYPE, "") || !XSupportsLocale())
-		fputs("warning: no locale support\n", stderr);
-	if (!(dpy = XOpenDisplay(NULL)))
-		die("dwm: cannot open display");
-	checkotherwm();
-	setup();
+int main(int argc, char *argv[]) {
+  if (argc == 2 && !strcmp("-v", argv[1]))
+    die("dwm-" VERSION);
+  else if (argc != 1)
+    die("usage: dwm [-v]");
+  if (!setlocale(LC_CTYPE, "") || !XSupportsLocale())
+    fputs("warning: no locale support\n", stderr);
+  if (!(dpy = XOpenDisplay(NULL)))
+    die("dwm: cannot open display");
+  checkotherwm();
+  setup();
 #ifdef __OpenBSD__
-	if (pledge("stdio rpath proc exec", NULL) == -1)
-		die("pledge");
+  if (pledge("stdio rpath proc exec", NULL) == -1)
+    die("pledge");
 #endif /* __OpenBSD__ */
-	scan();
-	run();
-	cleanup();
-	XCloseDisplay(dpy);
-	return EXIT_SUCCESS;
+  scan();
+  run();
+  cleanup();
+  XCloseDisplay(dpy);
+  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
config:
- Refatorar paleta de cores: variáveis genéricas (col_1..col_7) com aliases semânticos via #define (bar_bg, sel_bg, border_focused, dmenu_*)
- Trocar fonte do dmenu para JetBrainsMono Nerd Font Mono:size=11
- Simplificar tags para números 1-9 (remover ícones Nerd Font)
- Adicionar regras para Telegram (tag 8) e Discord (tag 9, monitor 1)
- Trocar terminal de st para kitty -e tmux
- Adicionar terminal_multiplexer como constante configurável
- Adicionar keybindings de volume via XF86 + pamixer (up/down/mute)
- Adicionar gappx = 8 como constante global
- Atualizar símbolos de layout para 𝕋/𝔽/𝕄
- Adicionar clang-format off/on em torno de SHCMD

pertag patch (dwm.c):
- Adicionar struct Pertag com estado por tag: curtag/prevtag, nmasters, mfacts, sellts, ltidxs, showbars
- Adicionar campo pertag ao Monitor e alocar/inicializar em createmon()
- Liberar pertag->pertag em cleanupmon()
- Atualizar view() para salvar/restaurar estado por tag ao trocar de tag
- Atualizar toggleview() para propagar configurações pertag ao novo tagset
- Atualizar setlayout(), setmfact(), incnmaster(), togglebar() para persistir estado no pertag do tag atual

estilo:
- Reformatar todo dwm.c de tabs para espaços (2-space indent, clang-format style)
- Renomear class hint da bar de 'dwm' para 'dwm-bar'
- Remover duplicate #define XEMBED_WINDOW_ACTIVATE